### PR TITLE
Makefile: add rpc and go.mod check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 cache:
   directories:
   - $GOCACHE
+  - $GOPATH/src/github.com/grpc-ecosystem
+  - $GOPATH/src/gopkg.in/alecthomas
+  - $GOPATH/src/google.golang.org
 
 go:
   - "1.13.x"
@@ -12,8 +15,12 @@ env:
 
 sudo: required
 
+before_script:
+  - bash ./scripts/install_travis_proto.sh
+
 script:
   - export GO111MODULE=on
+  - make rpc-check
   - make lint unit
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
 script:
   - export GO111MODULE=on
   - make rpc-check
+  - make mod-check
   - make lint unit
 
 after_script:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ DEPGET := cd /tmp && GO111MODULE=on go get -v
 GOBUILD := GO111MODULE=on go build -v
 GOINSTALL := GO111MODULE=on go install -v
 GOTEST := GO111MODULE=on go test -v
+GOMOD := GO111MODULE=on go mod
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 GOLIST := go list -deps $(PKG)/... | grep '$(PKG)'| grep -v '/vendor/'
@@ -116,6 +117,15 @@ fmt:
 lint: $(LINT_BIN)
 	@$(call print, "Linting source.")
 	$(LINT)
+
+mod:
+	@$(call print, "Tidying modules.")
+	$(GOMOD) tidy
+
+mod-check:
+	@$(call print, "Checking modules.")
+	$(GOMOD) tidy
+	if test -n "$$(git status | grep -e "go.mod\|go.sum")"; then echo "Running go mod tidy changes go.mod/go.sum"; git status; git diff; exit 1; fi
 
 rpc:
 	@$(call print, "Compiling protos.")

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,10 @@ rpc:
 	@$(call print, "Compiling protos.")
 	cd ./frdrpc; ./gen_protos.sh
 
+rpc-check: rpc
+	@$(call print, "Verifying protos.")
+	if test -n "$$(git describe --dirty | grep dirty)"; then echo "Protos not properly formatted or not compiled with v3.4.0"; git status; git diff; exit 1; fi
+
 rpc-format:
 	@$(call print, "Formatting protos.")
 	cd ./frdrpc; find . -name "*.proto" | xargs clang-format --style=file -i
@@ -131,6 +135,7 @@ list:
 		awk -F':' '/^[a-zA-Z0-9][^$$#\/\t=]*:([^=]|$$)/ {split($$1,A,/ /);for(i in A)print A[i]}' | \
 		grep -v Makefile | \
 		sort
+
 clean:
 	@$(call print, "Cleaning source.$(NC)")
 	$(RM) ./faraday

--- a/scripts/install_travis_proto.sh
+++ b/scripts/install_travis_proto.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Abort on error (-e) and print commands (-v).
+set -ev
+
+# Faraday uses the same versions/commits as lnd.
+PROTOC_VERSION=3.4.0
+PROTOBUF_VERSION="b5d812f8a3706043e23a9cd5babf2e5423744d30"
+GENPROTO_VERSION="a8101f21cf983e773d0c1133ebc5424792003214"
+GRPC_GATEWAY_VERSION="v1.8.6"
+
+# This script is specific to Travis CI so we only need to support linux x64.
+PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+PROTOC_DL_CACHE_DIR="${DOWNLOAD_CACHE:-/tmp/download_cache}/protoc"
+
+# install_protoc copies the cached protoc binary to the $PATH or downloads it
+# if no cached version is found.
+install_protoc() {
+  if [ -f "${PROTOC_DL_CACHE_DIR}/bin/protoc" ]; then
+    echo "Using cached version of protoc"
+  else
+    wget -O /tmp/protoc.zip $PROTOC_URL
+    mkdir -p "${PROTOC_DL_CACHE_DIR}"
+    unzip -o /tmp/protoc.zip -d "${PROTOC_DL_CACHE_DIR}"
+    chmod -R a+rx "${PROTOC_DL_CACHE_DIR}/"
+  fi
+  sudo cp "${PROTOC_DL_CACHE_DIR}/bin/protoc" /usr/local/bin
+  sudo cp -r "${PROTOC_DL_CACHE_DIR}/include" /usr/local
+}
+
+# install_protobuf downloads and compiles the Golang protobuf library that
+# encodes/decodes all protobuf messages from/to Go structs.
+install_protobuf() {
+  local install_path="$GOPATH/src/github.com/golang/protobuf"
+  if [ ! -d "$install_path" ]; then
+    git clone https://github.com/golang/protobuf "$install_path"
+  fi
+  pushd "$install_path"
+  git reset --hard $PROTOBUF_VERSION
+  make
+  popd
+}
+
+# install_genproto downloads the Golang protobuf generator that converts the
+# .proto files into Go interface stubs.
+install_genproto() {
+  local install_path="$GOPATH/src/google.golang.org/genproto"
+  if [ ! -d "$install_path" ]; then
+    git clone https://github.com/google/go-genproto "$install_path"
+  fi
+  pushd "$install_path"
+  git reset --hard $GENPROTO_VERSION
+  popd
+}
+
+# install_grpc_gateway downloads and installs the gRPC gateway that converts
+# .proto files into REST gateway code.
+install_grpc_gateway() {
+  local install_path="$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway"
+  if [ ! -d "$install_path" ]; then
+    git clone https://github.com/grpc-ecosystem/grpc-gateway "$install_path"
+  fi
+  pushd "$install_path"
+  git reset --hard $GRPC_GATEWAY_VERSION
+  GO111MODULE=on go install ./protoc-gen-grpc-gateway ./protoc-gen-swagger
+  popd
+}
+
+install_protoc
+install_protobuf
+install_genproto
+install_grpc_gateway


### PR DESCRIPTION
rpc-check logic copied across from lnd

Add a check for changes in `go.mod`/`go.sum` by running `go mod tidy` and then grepping for go.mod/ go.sum in the output of `git status`. Chose this approach rather than `git describe --dirty` so that the mod check could be run in between the proto install script and proto check without triggering a false positive on potential rpc changes. 