### PR TITLE
fiat: export get data and get price functions

### DIFF
--- a/fiat/coincap_api.go
+++ b/fiat/coincap_api.go
@@ -105,7 +105,7 @@ type coinCapAPI struct {
 
 	// convert produces usd prices from the output of the query function.
 	// It is set within the struct so that it can be mocked for testing.
-	convert func([]byte) ([]*usdPrice, error)
+	convert func([]byte) ([]*USDPrice, error)
 }
 
 // newCoinCapAPI returns a coin cap api struct which can be used to query
@@ -154,13 +154,13 @@ type coinCapDataPoint struct {
 
 // parseCoinCapData parses http response data to usc price structs, using
 // intermediary structs to get around parsing.
-func parseCoinCapData(data []byte) ([]*usdPrice, error) {
+func parseCoinCapData(data []byte) ([]*USDPrice, error) {
 	var priceEntries coinCapResponse
 	if err := json.Unmarshal(data, &priceEntries); err != nil {
 		return nil, err
 	}
 
-	var usdRecords = make([]*usdPrice, len(priceEntries.Data))
+	var usdRecords = make([]*USDPrice, len(priceEntries.Data))
 
 	// Convert each entry from the api to a usable record with a converted
 	// time and parsed price.
@@ -170,7 +170,7 @@ func parseCoinCapData(data []byte) ([]*usdPrice, error) {
 			return nil, err
 		}
 
-		usdRecords[i] = &usdPrice{
+		usdRecords[i] = &USDPrice{
 			timestamp: time.Unix(0, entry.Timestamp),
 			price:     floatPrice,
 		}
@@ -184,7 +184,7 @@ func parseCoinCapData(data []byte) ([]*usdPrice, error) {
 // because the more granular we want our price data to be, the smaller the
 // period coincap allows us to query is.
 func (c *coinCapAPI) GetPrices(ctx context.Context, startTime,
-	endTime time.Time) ([]*usdPrice, error) {
+	endTime time.Time) ([]*USDPrice, error) {
 
 	// First, check that we have a valid start and end time, and that the
 	// range specified is not in the future.
@@ -225,7 +225,7 @@ func (c *coinCapAPI) GetPrices(ctx context.Context, startTime,
 		return nil, errPeriodTooLong
 	}
 
-	var historicalRecords []*usdPrice
+	var historicalRecords []*USDPrice
 	queryStart := startTime
 
 	// The number of requests we require may be a fraction, so we use a

--- a/fiat/coincap_api_test.go
+++ b/fiat/coincap_api_test.go
@@ -103,7 +103,7 @@ func TestCoinCapGetPrices(t *testing.T) {
 			}
 
 			// Create a mocked convert function.
-			convert := func([]byte) ([]*usdPrice, error) {
+			convert := func([]byte) ([]*USDPrice, error) {
 				return nil, nil
 			}
 

--- a/fiat/fiat.go
+++ b/fiat/fiat.go
@@ -21,8 +21,8 @@ var (
 	errRetriesFailed = errors.New("could not get data within max retries")
 )
 
-// usdPrice represents the Bitcoin price in USD at a certain time.
-type usdPrice struct {
+// USDPrice represents the Bitcoin price in USD at a certain time.
+type USDPrice struct {
 	timestamp time.Time
 	price     float64
 }
@@ -32,7 +32,7 @@ type usdPrice struct {
 // context passed in. It takes query and convert functions as parameters for
 // testing purposes.
 func retryQuery(ctx context.Context, queryAPI func() ([]byte, error),
-	convert func([]byte) ([]*usdPrice, error)) ([]*usdPrice, error) {
+	convert func([]byte) ([]*USDPrice, error)) ([]*USDPrice, error) {
 
 	for i := 0; i < maxRetries; i++ {
 		// If our request fails, log the error, sleep for the retry

--- a/fiat/fiat_test.go
+++ b/fiat/fiat_test.go
@@ -101,7 +101,7 @@ func TestRetryQuery(t *testing.T) {
 			}
 
 			// Create a mocked parse call which acts as a nop.
-			parse := func([]byte) ([]*usdPrice, error) {
+			parse := func([]byte) ([]*USDPrice, error) {
 				return nil, nil
 			}
 

--- a/fiat/prices.go
+++ b/fiat/prices.go
@@ -72,7 +72,7 @@ func GetPrices(ctx context.Context, requests []*PriceRequest,
 
 // CoinCapPriceData obtains price data over a given range for coincap.
 func CoinCapPriceData(ctx context.Context, start, end time.Time,
-	granularity Granularity) ([]*usdPrice, error) {
+	granularity Granularity) ([]*USDPrice, error) {
 
 	coinCapBackend := newCoinCapAPI(granularity)
 	return coinCapBackend.GetPrices(ctx, start, end)
@@ -108,7 +108,7 @@ func msatToUSD(price float64, amt lnwire.MilliSatoshi) float64 {
 // GetPrice gets the price for a timestamped request from a set of price data.
 // This function expects the price data to be sorted with ascending timestamps.
 // If request lies between two price points, we simply aggregate the two prices.
-func GetPrice(prices []*usdPrice, request *PriceRequest) (float64, error) {
+func GetPrice(prices []*USDPrice, request *PriceRequest) (float64, error) {
 	var lastPrice float64
 
 	if len(prices) == 0 {

--- a/fiat/prices.go
+++ b/fiat/prices.go
@@ -50,9 +50,7 @@ func GetPrices(ctx context.Context, requests []*PriceRequest,
 	// so that we can efficiently query for price data.
 	start, end := getQueryableDuration(requests)
 
-	// Get a set of historical price data points.
-	coinCapBackend := newCoinCapAPI(granularity)
-	priceData, err := coinCapBackend.GetPrices(ctx, start, end)
+	priceData, err := CoinCapPriceData(ctx, start, end, granularity)
 	if err != nil {
 		return nil, err
 	}
@@ -70,6 +68,14 @@ func GetPrices(ctx context.Context, requests []*PriceRequest,
 	}
 
 	return prices, nil
+}
+
+// CoinCapPriceData obtains price data over a given range for coincap.
+func CoinCapPriceData(ctx context.Context, start, end time.Time,
+	granularity Granularity) ([]*usdPrice, error) {
+
+	coinCapBackend := newCoinCapAPI(granularity)
+	return coinCapBackend.GetPrices(ctx, start, end)
 }
 
 // getQueryableDuration gets the smallest and largest timestamp from a set of

--- a/fiat/prices.go
+++ b/fiat/prices.go
@@ -61,7 +61,7 @@ func GetPrices(ctx context.Context, requests []*PriceRequest,
 	var prices = make(map[string]float64, len(requests))
 
 	for _, request := range requests {
-		price, err := getPrice(priceData, request)
+		price, err := GetPrice(priceData, request)
 		if err != nil {
 			return nil, err
 		}
@@ -99,10 +99,10 @@ func msatToUSD(price float64, amt lnwire.MilliSatoshi) float64 {
 	return price * btcBal
 }
 
-// getPrice gets the price for a timestamped request from a set of price data.
+// GetPrice gets the price for a timestamped request from a set of price data.
 // This function expects the price data to be sorted with ascending timestamps.
 // If request lies between two price points, we simply aggregate the two prices.
-func getPrice(prices []*usdPrice, request *PriceRequest) (float64, error) {
+func GetPrice(prices []*usdPrice, request *PriceRequest) (float64, error) {
 	var lastPrice float64
 
 	if len(prices) == 0 {

--- a/fiat/prices_test.go
+++ b/fiat/prices_test.go
@@ -107,7 +107,7 @@ func TestGetPrice(t *testing.T) {
 		test := test
 
 		t.Run(test.name, func(t *testing.T) {
-			price, err := getPrice(test.prices, test.request)
+			price, err := GetPrice(test.prices, test.request)
 			if err != test.expectedErr {
 				t.Fatalf("expected: %v, got: %v",
 					test.expectedErr, err)

--- a/fiat/prices_test.go
+++ b/fiat/prices_test.go
@@ -15,7 +15,7 @@ func TestGetPrice(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		prices        []*usdPrice
+		prices        []*USDPrice
 		request       *PriceRequest
 		expectedErr   error
 		expectedPrice float64
@@ -31,7 +31,7 @@ func TestGetPrice(t *testing.T) {
 		},
 		{
 			name: "timestamp before range",
-			prices: []*usdPrice{
+			prices: []*USDPrice{
 				{
 					timestamp: now,
 					price:     10000,
@@ -46,7 +46,7 @@ func TestGetPrice(t *testing.T) {
 		},
 		{
 			name: "timestamp equals data point timestamp",
-			prices: []*usdPrice{
+			prices: []*USDPrice{
 				{
 					timestamp: oneHourAgo,
 					price:     10000,
@@ -65,7 +65,7 @@ func TestGetPrice(t *testing.T) {
 		},
 		{
 			name: "timestamp after range",
-			prices: []*usdPrice{
+			prices: []*USDPrice{
 				{
 					timestamp: twoHoursAgo,
 					price:     20000,
@@ -84,7 +84,7 @@ func TestGetPrice(t *testing.T) {
 		},
 		{
 			name: "timestamp between prices, aggregated",
-			prices: []*usdPrice{
+			prices: []*USDPrice{
 				{
 					timestamp: twoHoursAgo,
 					price:     20000,


### PR DESCRIPTION
To create accounting reports, we need to individually examine each on chain transaction we have to determine what amounts need to be converted to fiat values. Eg, a channel open needs to be examined to determine whether we paid opening fees or not to determine whether we need to convert that value to fiat or not.

The current fiat api is designed to allow querying of many prices at once, rather than getting of individual price points. To allow us to make a single query to the external price api then get fiat prices as required, we export separate `GetPrice` and `GetData` calls. 