### PR TITLE
rpcserver+config: prepare to be used as a library

### DIFF
--- a/cmd/frcli/main.go
+++ b/cmd/frcli/main.go
@@ -16,6 +16,11 @@ var (
 			"needed if faraday runs in the same process " +
 			"as lnd (GrUB)",
 	}
+	macaroonPathFlag = cli.StringFlag{
+		Name: "macaroonpath",
+		Usage: "path to macaroon file, only needed if faraday runs " +
+			"in the same process as lnd (GrUB)",
+	}
 )
 
 func main() {
@@ -30,6 +35,7 @@ func main() {
 			Usage: "host:port of faraday",
 		},
 		tlsCertFlag,
+		macaroonPathFlag,
 	}
 	app.Commands = []cli.Command{
 		thresholdRecommendationCommand,

--- a/cmd/frcli/main.go
+++ b/cmd/frcli/main.go
@@ -10,6 +10,12 @@ import (
 var (
 	defaultRPCPort     = "8465"
 	defaultRPCHostPort = "localhost:" + defaultRPCPort
+	tlsCertFlag        = cli.StringFlag{
+		Name: "tlscertpath",
+		Usage: "path to faraday's TLS certificate, only " +
+			"needed if faraday runs in the same process " +
+			"as lnd (GrUB)",
+	}
 )
 
 func main() {
@@ -23,6 +29,7 @@ func main() {
 			Value: defaultRPCHostPort,
 			Usage: "host:port of faraday",
 		},
+		tlsCertFlag,
 	}
 	app.Commands = []cli.Command{
 		thresholdRecommendationCommand,

--- a/cmd/frcli/utils.go
+++ b/cmd/frcli/utils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 
@@ -12,15 +13,21 @@ import (
 	"github.com/lightninglabs/protobuf-hex-display/jsonpb"
 	"github.com/lightninglabs/protobuf-hex-display/proto"
 	"github.com/lightningnetwork/lnd/lncfg"
+	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"gopkg.in/macaroon.v2"
 )
 
 var (
 	// maxMsgRecvSize is the largest message our client will receive. We
 	// set this to 200MiB atm.
 	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 200)
+
+	// defaultMacaroonTimeout is the default macaroon timeout in seconds
+	// that we set when sending it over the line.
+	defaultMacaroonTimeout int64 = 60
 )
 
 // fatal logs and error and exits.
@@ -94,6 +101,14 @@ func getClientConn(ctx *cli.Context) *grpc.ClientConn {
 			fatal(err)
 		}
 
+		// Macaroons are only allowed to be transmitted over a TLS
+		// enabled connection.
+		if ctx.GlobalIsSet(macaroonPathFlag.Name) {
+			opts = append(opts, readMacaroon(
+				ctx.GlobalString(macaroonPathFlag.Name),
+			))
+		}
+
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 
 	// By default, if no certificate is supplied, we assume the RPC server
@@ -127,4 +142,46 @@ func clientAddressDialer(defaultPort string) func(context.Context,
 			ctx, parsedAddr.Network(), parsedAddr.String(),
 		)
 	}
+}
+
+// readMacaroon tries to read the macaroon file at the specified path and create
+// gRPC dial options from it.
+//
+// TODO(guggero): Provide this function in lnd's macaroon package and use it
+// from there.
+func readMacaroon(macPath string) grpc.DialOption {
+	// Load the specified macaroon file.
+	macBytes, err := ioutil.ReadFile(macPath)
+	if err != nil {
+		fatal(fmt.Errorf("unable to read macaroon path : %v", err))
+	}
+
+	mac := &macaroon.Macaroon{}
+	if err = mac.UnmarshalBinary(macBytes); err != nil {
+		fatal(fmt.Errorf("unable to decode macaroon: %v", err))
+	}
+
+	macConstraints := []macaroons.Constraint{
+		// We add a time-based constraint to prevent replay of the
+		// macaroon. It's good for 60 seconds by default to make up for
+		// any discrepancy between client and server clocks, but leaking
+		// the macaroon before it becomes invalid makes it possible for
+		// an attacker to reuse the macaroon. In addition, the validity
+		// time of the macaroon is extended by the time the server clock
+		// is behind the client clock, or shortened by the time the
+		// server clock is ahead of the client clock (or invalid
+		// altogether if, in the latter case, this time is more than 60
+		// seconds).
+		macaroons.TimeoutConstraint(defaultMacaroonTimeout),
+	}
+
+	// Apply constraints to the macaroon.
+	constrainedMac, err := macaroons.AddConstraints(mac, macConstraints...)
+	if err != nil {
+		fatal(err)
+	}
+
+	// Now we append the macaroon credentials to the dial options.
+	cred := macaroons.NewMacaroonCredential(constrainedMac)
+	return grpc.WithPerRPCCredentials(cred)
 }

--- a/config.go
+++ b/config.go
@@ -60,13 +60,9 @@ type config struct {
 	CORSOrigin string `long:"corsorigin" description:"The value to send in the Access-Control-Allow-Origin header. Header will be omitted if empty."`
 }
 
-// loadConfig starts with a skeleton default config, and reads in user provided
-// configuration from the command line. It does not provide a full set of
-// defaults or validate user input because validation and sensible default
-// setting are performed by the lndclient package.
-func loadConfig() (*config, error) {
-	// Start with a default config.
-	config := &config{
+// DefaultConfig returns all default values for the config struct.
+func DefaultConfig() config {
+	return config{
 		RPCServer:        defaultRPCHostPort,
 		network:          defaultNetwork,
 		MacaroonFile:     defaultMacaroon,
@@ -74,9 +70,18 @@ func loadConfig() (*config, error) {
 		DebugLevel:       defaultDebugLevel,
 		RPCListen:        defaultRPCListen,
 	}
+}
+
+// LoadConfig starts with a skeleton default config, and reads in user provided
+// configuration from the command line. It does not provide a full set of
+// defaults or validate user input because validation and sensible default
+// setting are performed by the lndclient package.
+func LoadConfig() (*config, error) {
+	// Start with a default config.
+	config := DefaultConfig()
 
 	// Parse command line options to obtain user specified values.
-	if _, err := flags.Parse(config); err != nil {
+	if _, err := flags.Parse(&config); err != nil {
 		return nil, err
 	}
 
@@ -102,5 +107,5 @@ func loadConfig() (*config, error) {
 		return nil, err
 	}
 
-	return config, nil
+	return &config, nil
 }

--- a/config.go
+++ b/config.go
@@ -18,7 +18,7 @@ const (
 	defaultRPCListen      = "localhost:8465"
 )
 
-type config struct {
+type Config struct {
 	// RPCServer is host:port that lnd's RPC server is listening on.
 	RPCServer string `long:"rpcserver" description:"host:port that LND is listening for RPC connections on"`
 
@@ -60,9 +60,9 @@ type config struct {
 	CORSOrigin string `long:"corsorigin" description:"The value to send in the Access-Control-Allow-Origin header. Header will be omitted if empty."`
 }
 
-// DefaultConfig returns all default values for the config struct.
-func DefaultConfig() config {
-	return config{
+// DefaultConfig returns all default values for the Config struct.
+func DefaultConfig() Config {
+	return Config{
 		RPCServer:        defaultRPCHostPort,
 		network:          defaultNetwork,
 		MacaroonFile:     defaultMacaroon,
@@ -76,7 +76,7 @@ func DefaultConfig() config {
 // configuration from the command line. It does not provide a full set of
 // defaults or validate user input because validation and sensible default
 // setting are performed by the lndclient package.
-func LoadConfig() (*config, error) {
+func LoadConfig() (*Config, error) {
 	// Start with a default config.
 	config := DefaultConfig()
 

--- a/faraday.go
+++ b/faraday.go
@@ -12,7 +12,7 @@ import (
 // Main is the real entry point for faraday. It is required to ensure that
 // defers are properly executed when os.Exit() is called.
 func Main() error {
-	config, err := loadConfig()
+	config, err := LoadConfig()
 	if err != nil {
 		return fmt.Errorf("error loading config: %v", err)
 	}

--- a/faraday.go
+++ b/faraday.go
@@ -40,6 +40,8 @@ func Main() error {
 		},
 	)
 
+	// Catch intercept signals, then start the server.
+	signal.Intercept()
 	if err := server.Start(); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/urfave/cli v1.20.0
 	google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c
 	google.golang.org/grpc v1.27.0
+	gopkg.in/macaroon.v2 v2.1.0
 )
 
 go 1.13


### PR DESCRIPTION
To be able to run `faraday` as a library, we need to export some config related elements and create the possibility to instantiate and run the RPC server without it creating its own `grpc.Server` server or REST `proxy.ServeMux` instance.