### PR TITLE
version: bump to 0.2.0-alpha

### DIFF
--- a/version.go
+++ b/version.go
@@ -23,7 +23,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 0
-	appMinor uint = 1
+	appMinor uint = 2
 	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet


### PR DESCRIPTION
After https://github.com/lightninglabs/faraday/pull/41 is merged, we should tag a new version.