### PR TITLE
bugfix: add continue after adding open channel entry

### DIFF
--- a/accounting/on_chain.go
+++ b/accounting/on_chain.go
@@ -133,6 +133,7 @@ func onChainReport(txns []lndclient.Transaction, priceFunc msatToFiat,
 				return nil, err
 			}
 			report = append(report, entries...)
+			continue
 		}
 
 		// If the transaction is a channel opening transaction for one


### PR DESCRIPTION
If we do not continue after adding an open channel event, we will
double count our channel open as an on chain payment.