### PR TITLE
readme: add chain connection instructions and development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ make check
 ## Usage
 Faraday connects to a single instance of lnd. It requires access to macaroons for each subserver and a valid TLS certificate. It will attempt to use the default lnd values if no command line flags are specified.
 ```
-./faraday                                    \
+./faraday                                       \
 --macaroondir={directory containing macaroon}   \
 --tlscertpath={path to lnd cert}                \
---rpserver={host:port of lnd's rpserver} 
+--rpcserver={host:port of lnd's rpcserver} 
 ```
 
 By default, faraday runs on mainnet. The `--testnet`, `--simnet` or `--regtest` flags can be used to run in test environments.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ Faraday connects to a single instance of lnd. It requires access to macaroons fo
 
 By default, faraday runs on mainnet. The `--testnet`, `--simnet` or `--regtest` flags can be used to run in test environments.
 
+### Chain Backend
+Faraday offers node accounting services which require access to a Bitcoin node with `--txindex` set so that it can perform transaction lookup. Currently the `NodeReport` and `CloseReport` endpoints require this connection, and will fail if it is not present. This connection is *optional*, and all other endpoints will function if it is not configured. 
+
+To connect Faraday to bitcoind:
+```
+--connect_bitcoin                       \
+--bitcoin.host={host:port of bitcoind}  \
+--bitcoin.user={bitcoind username}      \
+--bitcoin.password={bitcoind  password}
+```
+
+To connect Faraday to btcd:
+```
+--connect_bitcoin                   \
+--bitcoin.host={host:port of btcd}  \
+--bitcoin.user={btcd username}      \
+--bitcoin.password={btcd password}  \
+--bitcoin.usetls                    \
+--bitcoin.tlspath={path to btcd cert}
+```
+
 #### RPCServer
 Faraday serves requests over grpc by default on `localhost:8465`. This default can be overwritten:
 ```
@@ -56,6 +77,9 @@ The RPC server can be conveniently accessed using a command line tool.
 - `revenue`: generate a revenue report over a time period for one or many channels.
 - `outliers`: close recommendations based whether channels are outliers based on a variety of metrics.
 - `threshold`: close recommendations based on thresholds a variety of metrics.
+- `nodereport`: produce an accounting report for your node over a period of time, please see the [accounting documentation](https://github.com/lightninglabs/faraday/blob/master/accounting/docs.md) for details. *Requires chain backend*.
+- `fiat`: get the USD price for an amount of Bitcoin at a given time, currently obtained from CoinCap's [historical price API](https://docs.coincap.io/?version=latest).
+- `closereports`: provides a channel specific fee report, including fees paid on chain. This endpoint is currently only implemented for cooperative closes.  *Requires chain backend*.
 
 #### Metrics currently tracked
 The following metrics are tracked in faraday and exposed via `insights` and used for `outliers` and `threshold` close recommendations.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,6 @@ cd $GOPATH/src/github.com/lightninglabs/faraday
 make && make install
 ```
 
-#### Tests
-To run all the unit tests in the repo, use:
-
-```
-make check
-```
-
 ## Usage
 Faraday connects to a single instance of lnd. It requires access to macaroons for each subserver and a valid TLS certificate. It will attempt to use the default lnd values if no command line flags are specified.
 ```
@@ -88,3 +81,21 @@ The following metrics are tracked in faraday and exposed via `insights` and used
 - Total Volume
 - Incoming Volume
 - Outgoing Volume
+
+## Development
+If you would like to contribute to Faraday, please see our [issues page](https://github.com/lightninglabs/faraday/issues) for currently open issues. If a feature that you would like to add is not covered by an existing issue, please open an issue to discuss the proposed addition. Contributions are hugely appreciated, and we will do our best to review pull requests timeously. 
+
+### Tests
+To run all the unit tests in the repo:
+```
+make check
+```
+To run Faraday's itests locally, you will need docker installed. To run all itests:
+```
+make itest
+```
+
+Individual itests can also be run using:
+```
+./run_itest.sh {test name}
+```


### PR DESCRIPTION
This PR updates Faraday's readme to include the latest instructions for running with a bitcoin backend, and adds a development section along with some typo fixes and formatting. 