### PR TITLE
multi: do not get best granularity when fiat is disabled

### DIFF
--- a/accounting/config.go
+++ b/accounting/config.go
@@ -85,13 +85,13 @@ type CommonConfig struct {
 
 	// Granularity specifies the level of granularity with which we want to
 	// get fiat prices.
-	Granularity fiat.Granularity
+	Granularity *fiat.Granularity
 }
 
 // NewOnChainConfig returns an on chain config from the lnd services provided.
 func NewOnChainConfig(ctx context.Context, lnd lndclient.LndServices, startTime,
 	endTime time.Time, disableFiat bool, txLookup fees.GetDetailsFunc,
-	granularity fiat.Granularity) *OnChainConfig {
+	granularity *fiat.Granularity) *OnChainConfig {
 
 	return &OnChainConfig{
 		OpenChannels: lndwrap.ListChannels(
@@ -127,7 +127,7 @@ func NewOnChainConfig(ctx context.Context, lnd lndclient.LndServices, startTime,
 func NewOffChainConfig(ctx context.Context, lnd lndclient.LndServices,
 	maxInvoices, maxPayments, maxForwards uint64, ownPubkey route.Vertex,
 	startTime, endTime time.Time, disableFiat bool,
-	granularity fiat.Granularity) *OffChainConfig {
+	granularity *fiat.Granularity) *OffChainConfig {
 
 	return &OffChainConfig{
 		ListInvoices: func() ([]lndclient.Invoice, error) {

--- a/cmd/frcli/node_report.go
+++ b/cmd/frcli/node_report.go
@@ -37,8 +37,8 @@ var onChainReportCommand = cli.Command{
 				"Note that write permissions are required.",
 		},
 		cli.BoolFlag{
-			Name:  "disable_fiat",
-			Usage: "Create a report without fiat conversions.",
+			Name:  "enable_fiat",
+			Usage: "Create a report with fiat conversions.",
 		},
 	},
 	Action: queryOnChainReport,
@@ -53,7 +53,7 @@ func queryOnChainReport(ctx *cli.Context) error {
 	req := &frdrpc.NodeReportRequest{
 		StartTime:   uint64(ctx.Int64("start_time")),
 		EndTime:     uint64(ctx.Int64("end_time")),
-		DisableFiat: ctx.IsSet("disable_fiat"),
+		DisableFiat: !ctx.IsSet("enable_fiat"),
 	}
 
 	// If start time is zero, default to a week ago.

--- a/frdrpc/node_report.go
+++ b/frdrpc/node_report.go
@@ -69,9 +69,14 @@ func rpcReportResponse(report accounting.Report) (*NodeReportResponse,
 			Reference: entry.Reference,
 			Note:      entry.Note,
 			BtcPrice: &BitcoinPrice{
-				Price:          entry.BTCPrice.Price.String(),
-				PriceTimestamp: uint64(entry.BTCPrice.Timestamp.Unix()),
+				Price: entry.BTCPrice.Price.String(),
 			},
+		}
+
+		if !entry.BTCPrice.Timestamp.IsZero() {
+			rpcEntry.BtcPrice.PriceTimestamp = uint64(
+				entry.BTCPrice.Timestamp.Unix(),
+			)
 		}
 
 		rpcType, err := rpcEntryType(entry.Type)

--- a/frdrpc/node_report.go
+++ b/frdrpc/node_report.go
@@ -26,7 +26,9 @@ func parseNodeReportRequest(ctx context.Context, cfg *Config,
 		return nil, nil, err
 	}
 
-	granularity, err := granularityFromRPC(req.Granularity, end.Sub(start))
+	granularity, err := granularityFromRPC(
+		req.Granularity, req.DisableFiat, end.Sub(start),
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/frdrpc/rpcserver.go
+++ b/frdrpc/rpcserver.go
@@ -325,7 +325,7 @@ func (s *RPCServer) ExchangeRate(ctx context.Context,
 		return nil, err
 	}
 
-	prices, err := fiat.GetPrices(ctx, timestamps, granularity)
+	prices, err := fiat.GetPrices(ctx, timestamps, *granularity)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR makes some small fixes to our node report's fiat:
- Make fiat opt-in on the cli
- Do not set granularity level when fiat is disabled
- Do not set zero value times when fiat is disabled