### PR TITLE
makefile: add import order check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
         - make mod-check
         - make rpc-check
         - make build
+        - make imports
       name: Build and lint
     - stage: Tests
       script: make unit

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,14 @@ LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
 GOVERALLS_PKG := github.com/mattn/goveralls
 GOACC_PKG := github.com/ory/go-acc
 
+IMPORTS_PKG := github.com/pavius/impi/cmd/impi
+IMPORTS_COMMIT := 3cdbde3d3cbb0ead2b9491272bccb5c652174656
+
 GO_BIN := ${GOPATH}/bin
 GOVERALLS_BIN := $(GO_BIN)/goveralls
 LINT_BIN := $(GO_BIN)/golangci-lint
 GOACC_BIN := $(GO_BIN)/go-acc
+IMPORTS_BIN := $(GO_BIN)/impi
 
 COMMIT := $(shell git describe --abbrev=40 --dirty)
 LDFLAGS := -ldflags "-X $(PKG).Commit=$(COMMIT)"
@@ -54,6 +58,10 @@ $(LINT_BIN):
 $(GOACC_BIN):
 	@$(call print, "Fetching go-acc")
 	$(DEPGET) $(GOACC_PKG)@$(GOACC_COMMIT)
+
+$(IMPORTS_BIN):
+	@$(call print, "Fetching imports check")
+	$(DEPGET) $(IMPORTS_PKG)@$(IMPORTS_COMMIT)
 
 # ============
 # INSTALLATION
@@ -117,6 +125,11 @@ flake-unit:
 fmt:
 	@$(call print, "Formatting source.")
 	gofmt -l -w -s $(GOFILES_NOVENDOR)
+
+imports: $(IMPORTS_BIN)
+	@$(call print, "Checking imports.")
+	$(IMPORTS_BIN) --local github.com/lightninglabs/faraday/ --scheme stdThirdPartyLocal --ignore-generated=true *
+
 
 lint: $(LINT_BIN)
 	@$(call print, "Linting source.")

--- a/accounting/config.go
+++ b/accounting/config.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/routing/route"
+
 	"github.com/lightninglabs/faraday/fees"
 	"github.com/lightninglabs/faraday/fiat"
 	"github.com/lightninglabs/faraday/lndwrap"
-	"github.com/lightninglabs/lndclient"
-	"github.com/lightningnetwork/lnd/routing/route"
 )
 
 // decodePaymentRequest is a signature for decoding payment requests.

--- a/accounting/conversions.go
+++ b/accounting/conversions.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcutil"
+
 	"github.com/lightninglabs/faraday/fiat"
 	"github.com/lightninglabs/faraday/utils"
 )

--- a/accounting/entries.go
+++ b/accounting/entries.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/lightningnetwork/lnd/routing/route"
-
 	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
 )
 
 // FeeReference returns a special unique reference for the fee paid on a

--- a/accounting/entries_test.go
+++ b/accounting/entries_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"github.com/lightninglabs/faraday/fiat"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -16,6 +15,8 @@ import (
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
+
+	"github.com/lightninglabs/faraday/fiat"
 )
 
 var (

--- a/accounting/on_chain.go
+++ b/accounting/on_chain.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"github.com/lightninglabs/faraday/utils"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
+
+	"github.com/lightninglabs/faraday/utils"
 )
 
 // OnChainReport produces a report of our on chain activity for a period using

--- a/accounting/report.go
+++ b/accounting/report.go
@@ -3,9 +3,10 @@ package accounting
 import (
 	"time"
 
-	"github.com/lightninglabs/faraday/fiat"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/shopspring/decimal"
+
+	"github.com/lightninglabs/faraday/fiat"
 )
 
 // Report contains a set of entries.

--- a/cmd/faraday/log.go
+++ b/cmd/faraday/log.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"github.com/btcsuite/btclog"
-	"github.com/lightninglabs/faraday"
 	"github.com/lightningnetwork/lnd/build"
+
+	"github.com/lightninglabs/faraday"
 )
 
 var (

--- a/cmd/frcli/channel_insights.go
+++ b/cmd/frcli/channel_insights.go
@@ -3,8 +3,9 @@ package main
 import (
 	"context"
 
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/urfave/cli"
+
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 var channelInsightsCommand = cli.Command{

--- a/cmd/frcli/close_recommendations.go
+++ b/cmd/frcli/close_recommendations.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/urfave/cli"
+
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 var (

--- a/cmd/frcli/close_reports.go
+++ b/cmd/frcli/close_reports.go
@@ -3,8 +3,9 @@ package main
 import (
 	"context"
 
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/urfave/cli"
+
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 var closeReportCommand = cli.Command{

--- a/cmd/frcli/fiat_estimate.go
+++ b/cmd/frcli/fiat_estimate.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/lightninglabs/faraday/fiat"
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/shopspring/decimal"
 	"github.com/urfave/cli"
+
+	"github.com/lightninglabs/faraday/fiat"
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 var fiatEstimateCommand = cli.Command{

--- a/cmd/frcli/main.go
+++ b/cmd/frcli/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/lightninglabs/faraday"
 	"github.com/urfave/cli"
+
+	"github.com/lightninglabs/faraday"
 )
 
 var (

--- a/cmd/frcli/node_report.go
+++ b/cmd/frcli/node_report.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/urfave/cli"
+
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 var onChainReportCommand = cli.Command{

--- a/cmd/frcli/revenue_report.go
+++ b/cmd/frcli/revenue_report.go
@@ -3,8 +3,9 @@ package main
 import (
 	"context"
 
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/urfave/cli"
+
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 var revenueReportCommand = cli.Command{

--- a/cmd/frcli/utils.go
+++ b/cmd/frcli/utils.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/faraday"
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/protobuf-hex-display/jsonpb"
 	"github.com/lightninglabs/protobuf-hex-display/proto"
@@ -25,6 +23,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"gopkg.in/macaroon.v2"
+
+	"github.com/lightninglabs/faraday"
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 var (

--- a/config.go
+++ b/config.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/btcsuite/btcutil"
 	"github.com/jessevdk/go-flags"
-	"github.com/lightninglabs/faraday/chain"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/cert"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/lightninglabs/faraday/chain"
 )
 
 const (

--- a/faraday.go
+++ b/faraday.go
@@ -4,10 +4,11 @@ package faraday
 import (
 	"fmt"
 
-	"github.com/lightninglabs/faraday/chain"
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/signal"
+
+	"github.com/lightninglabs/faraday/chain"
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 // Main is the real entry point for faraday. It is required to ensure that

--- a/fiat/coincap_api.go
+++ b/fiat/coincap_api.go
@@ -10,8 +10,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/lightninglabs/faraday/utils"
 	"github.com/shopspring/decimal"
+
+	"github.com/lightninglabs/faraday/utils"
 )
 
 const (

--- a/frdrpc/close_report.go
+++ b/frdrpc/close_report.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/lndclient"
+
 	"github.com/lightninglabs/faraday/fees"
 	"github.com/lightninglabs/faraday/resolutions"
-	"github.com/lightninglabs/lndclient"
 )
 
 func parseCloseReportRequest(ctx context.Context, cfg *Config) *resolutions.Config {

--- a/frdrpc/node_report.go
+++ b/frdrpc/node_report.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/lightninglabs/faraday/accounting"
 	"github.com/lightningnetwork/lnd/routing/route"
+
+	"github.com/lightninglabs/faraday/accounting"
 )
 
 // parseNodeReportRequest parses a report request and returns the config

--- a/frdrpc/revenue_report.go
+++ b/frdrpc/revenue_report.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/lightninglabs/lndclient"
+
 	"github.com/lightninglabs/faraday/lndwrap"
 	"github.com/lightninglabs/faraday/revenue"
-	"github.com/lightninglabs/lndclient"
 )
 
 // parseRevenueRequest parses a request for a revenue report and wraps

--- a/frdrpc/rpcserver.go
+++ b/frdrpc/rpcserver.go
@@ -21,15 +21,16 @@ import (
 	"sync/atomic"
 
 	proxy "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/lightninglabs/lndclient"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/lightninglabs/faraday/accounting"
 	"github.com/lightninglabs/faraday/chain"
 	"github.com/lightninglabs/faraday/fiat"
 	"github.com/lightninglabs/faraday/recommend"
 	"github.com/lightninglabs/faraday/resolutions"
 	"github.com/lightninglabs/faraday/revenue"
-	"github.com/lightninglabs/lndclient"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 var (

--- a/insights/insights.go
+++ b/insights/insights.go
@@ -3,9 +3,10 @@ package insights
 import (
 	"time"
 
-	"github.com/lightninglabs/faraday/revenue"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/lnwire"
+
+	"github.com/lightninglabs/faraday/revenue"
 )
 
 // ChannelInfo provides a set of performance metrics for a lightning channel.

--- a/insights/insights_test.go
+++ b/insights/insights_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lightninglabs/faraday/revenue"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/lnwire"
+
+	"github.com/lightninglabs/faraday/revenue"
 )
 
 // TestGetChannels tests gathering of channel insights from a set of lnrpc

--- a/itest/nodereport_test.go
+++ b/itest/nodereport_test.go
@@ -8,15 +8,16 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
-	"github.com/lightninglabs/faraday/accounting"
-	"github.com/lightninglabs/faraday/fees"
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
+
+	"github.com/lightninglabs/faraday/accounting"
+	"github.com/lightninglabs/faraday/fees"
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 var (

--- a/itest/rpc.go
+++ b/itest/rpc.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/rpcclient"
-	"github.com/lightninglabs/faraday/frdrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 // getBitcoindClient returns an rpc client connection to the running bitcoind

--- a/itest/test_context.go
+++ b/itest/test_context.go
@@ -12,7 +12,6 @@ import (
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -21,6 +20,8 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
+
+	"github.com/lightninglabs/faraday/frdrpc"
 )
 
 var (

--- a/lndwrap/lndwrap.go
+++ b/lndwrap/lndwrap.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/lightninglabs/faraday/paginater"
 	"github.com/lightninglabs/lndclient"
+
+	"github.com/lightninglabs/faraday/paginater"
 )
 
 // ListInvoices makes paginated calls to lnd to get our full set of

--- a/log.go
+++ b/log.go
@@ -2,13 +2,14 @@ package faraday
 
 import (
 	"github.com/btcsuite/btclog"
+	"github.com/lightningnetwork/lnd/build"
+
 	"github.com/lightninglabs/faraday/accounting"
 	"github.com/lightninglabs/faraday/dataset"
 	"github.com/lightninglabs/faraday/fiat"
 	"github.com/lightninglabs/faraday/frdrpc"
 	"github.com/lightninglabs/faraday/recommend"
 	"github.com/lightninglabs/faraday/revenue"
-	"github.com/lightningnetwork/lnd/build"
 )
 
 // Subsystem defines the logging code for this subsystem.

--- a/resolutions/resolutions.go
+++ b/resolutions/resolutions.go
@@ -8,9 +8,10 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"github.com/lightninglabs/faraday/utils"
 	"github.com/lightninglabs/lndclient"
 	"github.com/shopspring/decimal"
+
+	"github.com/lightninglabs/faraday/utils"
 )
 
 var (


### PR DESCRIPTION
This PR adds an import ordering check which can be used to detect stray newlines and mis-grouped imports using https://github.com/pavius/impi. This is chosen over `goimports`, because go imports run for everything in your `GOPATH`, which can be very slow locally. 

This tool cannot be applied from a start commit hash, so requires a once-off fix of import ordering in the project, which is included. This was done manually, because the tool only logs output. 