### PR TITLE
frcli: wrap tls cert error with explanation

### DIFF
--- a/cmd/frcli/utils.go
+++ b/cmd/frcli/utils.go
@@ -107,7 +107,8 @@ func getClientConn(ctx *cli.Context) *grpc.ClientConn {
 	// TLS cannot be disabled, we'll always have a cert file to read.
 	creds, err := credentials.NewClientTLSFromFile(tlsCertPath, "")
 	if err != nil {
-		fatal(err)
+		fatal(fmt.Errorf("unable to read tls cert (path: %v): %v",
+			tlsCertPath, err))
 	}
 
 	// Macaroons are not yet enabled by default.


### PR DESCRIPTION
With the addition of TLS, the `network` flag is now required to use `frcli` on regtest/testnet. 
Running [without the flag yields](https://github.com/lightninglabs/faraday/issues/67#issuecomment-689232160) `[frcli] open : no such file or directory`, which is quite ambiguous.

This PR wraps the error to more clearly explain what's gone wrong. 
Mentioned in #67