### PR TITLE
cmd/frcli: add default path for TLS cert

### DIFF
--- a/cmd/frcli/main.go
+++ b/cmd/frcli/main.go
@@ -25,6 +25,7 @@ var (
 	tlsCertFlag = cli.StringFlag{
 		Name:  "tlscertpath",
 		Usage: "path to faraday's TLS certificate",
+		Value: faraday.DefaultTLSCertPath,
 	}
 	macaroonPathFlag = cli.StringFlag{
 		Name: "macaroonpath",


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/faraday/issues/78.