### PR TITLE
Remove duplicate msat unit in outputs

### DIFF
--- a/accounting/entries.go
+++ b/accounting/entries.go
@@ -302,7 +302,7 @@ func invoiceNote(memo string, amt, amtPaid lnwire.MilliSatoshi,
 
 	if amt != amtPaid {
 		notes = append(notes, fmt.Sprintf("invoice overpaid "+
-			"original amount: %v msat, paid: %v", amt, amtPaid))
+			"original amount: %v, paid: %v", amt, amtPaid))
 	}
 
 	if keysend {
@@ -425,7 +425,7 @@ func forwardTxid(forward lndclient.ForwardingEvent) string {
 // forwardNote creates a note that indicates the amounts that were forwarded in
 // and out of our node.
 func forwardNote(amtIn, amtOut lnwire.MilliSatoshi) string {
-	return fmt.Sprintf("incoming: %v msat outgoing: %v msat", amtIn, amtOut)
+	return fmt.Sprintf("incoming: %v outgoing: %v", amtIn, amtOut)
 }
 
 // forwardingEntry produces a forwarding entry with a zero amount which reflects

--- a/accounting/entries.go
+++ b/accounting/entries.go
@@ -91,7 +91,7 @@ func channelOpenEntries(channel channelInfo, tx lndclient.Transaction,
 
 	// We also need an entry for the fees we paid for the on chain tx.
 	// Transactions record fees in absolute amounts in sats, so we need
-	// to convert fees to msat and filp it to a negative value so it
+	// to convert fees to msat and flip it to a negative value so it
 	// records as a debit.
 	feeMsat := invertedSatsToMsats(tx.Fee)
 
@@ -205,7 +205,7 @@ func sweepEntries(tx lndclient.Transaction, u entryUtils) ([]*HarmonyEntry, erro
 	}
 
 	// If we do not have a fee lookup function set, we log a warning that
-	// we cannot record fees for the sweep transaction and return wihtout
+	// we cannot record fees for the sweep transaction and return without
 	// adding a fee entry.
 	if u.getFee == nil {
 		log.Warnf("no bitcoin backend provided to lookup fees, "+
@@ -422,7 +422,7 @@ func forwardTxid(forward lndclient.ForwardingEvent) string {
 		forward.ChannelOut)
 }
 
-// forwardNote creates a note that indicates the amuonts that were forwarded in
+// forwardNote creates a note that indicates the amounts that were forwarded in
 // and out of our node.
 func forwardNote(amtIn, amtOut lnwire.MilliSatoshi) string {
 	return fmt.Sprintf("incoming: %v msat outgoing: %v msat", amtIn, amtOut)

--- a/accounting/entries_test.go
+++ b/accounting/entries_test.go
@@ -287,7 +287,7 @@ func TestChannelOpenEntry(t *testing.T) {
 			// At a minimum, we expect a channel entry to be present.
 			expectedChanEntry := getChannelEntry(test.initiator)
 
-			// If we opened the chanel, we also expect a fee entry
+			// If we opened the channel, we also expect a fee entry
 			// to be present.
 			expected := []*HarmonyEntry{expectedChanEntry}
 			if test.initiator {


### PR DESCRIPTION
Before: "incoming: 51 mSAT msat outgoing: 51 mSAT msat"
After:  "incoming: 51 mSAT outgoing: 51 mSAT"