### PR TITLE
multi: audit labelling bugfix, sort output and export paginator fn

### DIFF
--- a/frdrpc/node_audit.go
+++ b/frdrpc/node_audit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/lightningnetwork/lnd/routing/route"
 
@@ -177,6 +178,11 @@ func rpcReportResponse(report accounting.Report) (*NodeAuditResponse,
 
 		entries[i] = rpcEntry
 	}
+
+	// Sort report entries by timestamp.
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Timestamp < entries[j].Timestamp
+	})
 
 	return &NodeAuditResponse{Reports: entries}, nil
 }

--- a/frdrpc/node_audit.go
+++ b/frdrpc/node_audit.go
@@ -56,7 +56,7 @@ func parseNodeAuditRequest(ctx context.Context, cfg *Config,
 		return nil, nil, err
 	}
 
-	offChainCategories, onChainCategories, err := getCategories(
+	onChainCategories, offChainCategories, err := getCategories(
 		req.CustomCategories,
 	)
 	if err != nil {

--- a/paginater/paginater.go
+++ b/paginater/paginater.go
@@ -2,17 +2,17 @@ package paginater
 
 import "context"
 
-// paginatedQuery is a function which makes a call to a paginated api and adds
+// PaginatedQuery is a function which makes a call to a paginated api and adds
 // returns the index offset of the last entry and the number of events that were
 // returned.
-type paginatedQuery func(offset, maxEvents uint64) (uint64, uint64, error)
+type PaginatedQuery func(offset, maxEvents uint64) (uint64, uint64, error)
 
 // QueryPaginated gets calls the paginated query function until it it has
 // retrieved all the items from the query endpoint, or the calling context is
 // cancelled. Note that the query function is responsible for collecting the
 // items returned by the API (if required) so that the pagination logic can
 // remain generic.
-func QueryPaginated(ctx context.Context, query paginatedQuery, offset,
+func QueryPaginated(ctx context.Context, query PaginatedQuery, offset,
 	maxEvents uint64) error {
 
 	for {


### PR DESCRIPTION
This PR combines 3 unrelated issues:
- Sort the output of the audit command by timestamp, which has been requested by various users
- Bugfix: the rpc for custom categories switched onchain/offchain categories 
- Paginator: export the function type, because we're using this package in other projects a bit