### PR TITLE
multi: add pool category and in-repo release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,2 @@
+#### Pull Request Checklist
+- [ ] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes

--- a/cmd/frcli/node_audit.go
+++ b/cmd/frcli/node_audit.go
@@ -85,6 +85,14 @@ var onChainReportCommand = cli.Command{
 				"category currently does not include off " +
 				"chain payments.",
 		},
+		cli.BoolFlag{
+			Name: "pool-category",
+			Usage: "Add a custom category called 'pool' " +
+				"containing all transactions associated with " +
+				"Lightning Labs Pool trades. Note that this " +
+				"category currently does not include off " +
+				"chain payments.",
+		},
 	},
 	Action: queryOnChainReport,
 }
@@ -134,6 +142,19 @@ func queryOnChainReport(ctx *cli.Context) error {
 					"swap",
 				},
 			})
+	}
+
+	if ctx.Bool("pool-category") {
+		req.CustomCategories = append(
+			req.CustomCategories, &frdrpc.CustomCategory{
+				Name:     "pool",
+				OnChain:  true,
+				OffChain: true,
+				LabelPatterns: []string{
+					"poold --",
+				},
+			},
+		)
 	}
 
 	rpcCtx := context.Background()

--- a/release_notes.md
+++ b/release_notes.md
@@ -15,7 +15,10 @@ This file tracks release notes for the loop client.
 ## Next release
 
 #### New Features
+* The output of the `audit` rpc is now sorted by ascending timestamp. 
+* A pre-set custom category for [Lightning Pool](https://github.com/lightninglabs/pool) has been added to the `audit` cli, and can be used to separate all pool-related transactions into their own category called `pool` using `audit --pool-category`.
 
 #### Breaking Changes
 
 #### Bug Fixes
+* A bug in the `audit` custom categories functionality which switched on-chain and off-chain categories has been fixed. 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,21 @@
+# Loop Client Release Notes
+This file tracks release notes for the loop client. 
+
+### Developers: 
+* When new features are added to the repo, a short description of the feature should be added under the "Next Release" heading.
+* This should be done in the same PR as the change so that our release notes stay in sync!
+
+### Release Manager: 
+* All of the items under the "Next Release" heading should be included in the release notes.
+* As part of the PR that bumps the client version, cut everything below the 'Next Release' heading. 
+* These notes can either be pasted in a temporary doc, or you can get them from the PR diff once it is merged. 
+* The notes are just a guideline as to the changes that have been made since the last release, they can be updated.
+* Once the version bump PR is merged and tagged, add the release notes to the tag on GitHub.
+
+## Next release
+
+#### New Features
+
+#### Breaking Changes
+
+#### Bug Fixes

--- a/version.go
+++ b/version.go
@@ -22,6 +22,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).
 const (
+	// Please update release_notes.md when updating this!
 	appMajor uint = 0
 	appMinor uint = 2
 	appPatch uint = 2


### PR DESCRIPTION
This PR combines two small changes for brief review:
1. Now that pool has been released, we can add a pre-set custom category for pool so that pool txns can easily be separated out from regular lnd txns
2. Add in-repo release note tracking, and reminders in comments + PR template