### PR TITLE
multi: update fee function to only require inputs and outputs

### DIFF
--- a/fees/fees.go
+++ b/fees/fees.go
@@ -6,34 +6,35 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
-// GetDetailsFunc is a function which looks up transactions by hash.
-type GetDetailsFunc func(hash *chainhash.Hash) (*btcjson.TxRawResult, error)
+// GetDetailsFunc is a function which looks up transactions by hash, returning
+// its inputs and outputs.
+type GetDetailsFunc func(hash *chainhash.Hash) ([]btcjson.Vin,
+	[]btcjson.Vout, error)
 
 // CalculateFee returns the total fees for the transaction provided.
-// TODO(carla): identify change address and split fees between outputs.
 func CalculateFee(details GetDetailsFunc, txid *chainhash.Hash) (btcutil.Amount,
 	error) {
 
 	var fees btcutil.Amount
 
-	tx, err := details(txid)
+	inputs, outputs, err := details(txid)
 	if err != nil {
 		return 0, err
 	}
 
 	// Lookup each of our inputs and add their value to our fees.
-	for _, in := range tx.Vin {
+	for _, in := range inputs {
 		prevOutHash, err := chainhash.NewHashFromStr(in.Txid)
 		if err != nil {
 			return 0, err
 		}
 
-		tx, err := details(prevOutHash)
+		_, prevOuts, err := details(prevOutHash)
 		if err != nil {
 			return 0, err
 		}
 
-		prevOut := tx.Vout[in.Vout]
+		prevOut := prevOuts[in.Vout]
 		amt, err := btcutil.NewAmount(prevOut.Value)
 		if err != nil {
 			return 0, err
@@ -43,7 +44,7 @@ func CalculateFee(details GetDetailsFunc, txid *chainhash.Hash) (btcutil.Amount,
 	}
 
 	// Next, we minus total outputs from our fees.
-	for _, out := range tx.Vout {
+	for _, out := range outputs {
 		amt, err := btcutil.NewAmount(out.Value)
 		if err != nil {
 			return 0, err

--- a/fees/fees_test.go
+++ b/fees/fees_test.go
@@ -136,18 +136,20 @@ func TestTotalFees(t *testing.T) {
 }
 
 // getDetails mocks lookup for a node that has knowledge of tx1 and tx2.
-func getDetails(txHash *chainhash.Hash) (*btcjson.TxRawResult, error) {
+func getDetails(txHash *chainhash.Hash) ([]btcjson.Vin, []btcjson.Vout,
+	error) {
+
 	switch *txHash {
 	case *txid0:
-		return tx0, nil
+		return tx0.Vin, tx0.Vout, nil
 
 	case *txid1:
-		return tx1, nil
+		return tx1.Vin, tx1.Vout, nil
 
 	case *txid2:
-		return tx2, nil
+		return tx2.Vin, tx2.Vout, nil
 
 	default:
-		return nil, fmt.Errorf("transaction not found")
+		return nil, nil, fmt.Errorf("transaction not found")
 	}
 }

--- a/itest/nodereport_test.go
+++ b/itest/nodereport_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/lndclient"
@@ -210,8 +211,18 @@ func TestNodeAudit(t *testing.T) {
 	}
 
 	// Get our fee for our sweep tx.
+	detailsFunc := func(hash *chainhash.Hash) ([]btcjson.Vin,
+		[]btcjson.Vout, error) {
+		tx, err := c.bitcoindClient.GetRawTransactionVerbose(hash)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return tx.Vin, tx.Vout, nil
+	}
+
 	sweepFee, err := fees.CalculateFee(
-		c.bitcoindClient.GetRawTransactionVerbose, sweepHash,
+		detailsFunc, sweepHash,
 	)
 	require.NoError(c.t, err, "could get sweep fee")
 

--- a/resolutions/resolutions_test.go
+++ b/resolutions/resolutions_test.go
@@ -92,9 +92,9 @@ func TestGetClosedReport(t *testing.T) {
 			}
 
 			getTx := func(txHash *chainhash.Hash) (
-				*btcjson.TxRawResult, error) {
+				[]btcjson.Vin, []btcjson.Vout, error) {
 
-				return test.tx, nil
+				return test.tx.Vin, test.tx.Vout, nil
 			}
 
 			_, err := ChannelCloseReport(


### PR DESCRIPTION
We only need our inputs and outputs for fee calculation, so this
PR updates our various accounting related packages to change the
function signature required.

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
