### PR TITLE
rpcserver: let gRPC handle TLS to avoid ALPN error

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -19,3 +19,5 @@ This file tracks release notes for the loop client.
 #### Breaking Changes
 
 #### Bug Fixes
+ - Fixes a bug in how TLS connections were initialized which lead to the
+   `missing selected ALPN property` error in node.js and #c clients.


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/faraday/issues/97.

It seems there is a difference in how ALPN is handled between when gRPC
creates the TLS layer and when the golang library does it with
tls.NewListener. To fix the "missing selected ALPN property" error in
node.js and #c clients, we switch over the TLS handling to gRPC.

#### Pull Request Checklist
- [X] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
