### PR TITLE
release_notes+version: bump to v0.2.6-alpha

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -22,11 +22,6 @@ This file tracks release notes for the faraday client.
 ## Next release
 
 #### New Features
-* A single macaroon can now be specified to connect to `lnd` by changing the
-  `--lnd.macaroondir` to `--lnd.macaroonpath` and pointing it directly to either
-  the `readonly.macaroon` or a custom baked one. If none of the two flags are
-  specified, faraday falls back to the default `lnd` directory and the
-  `readonly.macaroon` file.
 
 #### Breaking Changes
 

--- a/version.go
+++ b/version.go
@@ -25,7 +25,7 @@ const (
 	// Please update release_notes.md when updating this!
 	appMajor uint = 0
 	appMinor uint = 2
-	appPatch uint = 4
+	appPatch uint = 6
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
Clear release notes and bump version to 0.2.6. Version jumps to
v0.2.6 because we did not bump the version file for v0.2.5, despite
having tagged it.

#### Pull Request Checklist
- [x] Update `release_notes.md` if your PR contains major features, breaking changes or bugfixes
