### PR TITLE
Macaroon stateless

### DIFF
--- a/frdrpc/macaroons.go
+++ b/frdrpc/macaroons.go
@@ -96,7 +96,7 @@ var (
 // startMacaroonService starts the macaroon validation service, creates or
 // unlocks the macaroon database and creates the default macaroon if it doesn't
 // exist yet.
-func (s *RPCServer) startMacaroonService() error {
+func (s *RPCServer) startMacaroonService(createDefaultMacaroonFile bool) error {
 	var err error
 	s.macaroonDB, err = kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
 		DBPath:     s.cfg.FaradayDir,
@@ -131,8 +131,11 @@ func (s *RPCServer) startMacaroonService() error {
 		return fmt.Errorf("unable to unlock macaroon DB: %v", err)
 	}
 
-	// Create macaroon files for faraday CLI to use if they don't exist.
-	if !lnrpc.FileExists(s.cfg.MacaroonPath) {
+	// There are situations in which we don't want a macaroon to be created
+	// on disk (for example when running inside LiT stateless integrated
+	// mode). For any other cases, we create macaroon files for the faraday
+	// CLI in the default directory.
+	if createDefaultMacaroonFile && !lnrpc.FileExists(s.cfg.MacaroonPath) {
 		// We don't offer the ability to rotate macaroon root keys yet,
 		// so just use the default one since the service expects some
 		// value to be set.

--- a/frdrpc/rpcserver.go
+++ b/frdrpc/rpcserver.go
@@ -182,7 +182,7 @@ func (s *RPCServer) Start() error {
 
 	// Start the macaroon service and let it create its default macaroon in
 	// case it doesn't exist yet.
-	if err := s.startMacaroonService(); err != nil {
+	if err := s.startMacaroonService(true); err != nil {
 		return fmt.Errorf("error starting macaroon service: %v", err)
 	}
 	shutdownFuncs["macaroon"] = s.stopMacaroonService
@@ -301,14 +301,16 @@ func (s *RPCServer) Start() error {
 // create its own gRPC server but registers to an existing one. The same goes
 // for REST (if enabled), instead of creating an own mux and HTTP server, we
 // register to an existing one.
-func (s *RPCServer) StartAsSubserver(lndClient lndclient.LndServices) error {
+func (s *RPCServer) StartAsSubserver(lndClient lndclient.LndServices,
+	createDefaultMacaroonFile bool) error {
+
 	if atomic.AddInt32(&s.started, 1) != 1 {
 		return errServerAlreadyStarted
 	}
 
 	// Start the macaroon service and let it create its default macaroon in
 	// case it doesn't exist yet.
-	if err := s.startMacaroonService(); err != nil {
+	if err := s.startMacaroonService(createDefaultMacaroonFile); err != nil {
 		return fmt.Errorf("error starting macaroon service: %v", err)
 	}
 

--- a/frdrpc/rpcserver.go
+++ b/frdrpc/rpcserver.go
@@ -347,7 +347,7 @@ func (s *RPCServer) Stop() error {
 		}
 	}
 
-	if err := s.macaroonService.Close(); err != nil {
+	if err := s.stopMacaroonService(); err != nil {
 		log.Errorf("Error stopping macaroon service: %v", err)
 	}
 


### PR DESCRIPTION
Replaces #127.

In some cases we don't want the default macaroon file to be created on
disk, so we allow passing in a boolean that toggles the macaroon
creation.

This is for the LiT stateless integrated mode.

#### Pull Request Checklist
- [ ] Update `release_notes.md` if your PR contains major features, breaking
  changes or bugfixes
- [ ] Update `MinLndVersion` if your PR uses new RPC methods or fields of `lnd`. 
