### PR TITLE
config: clean and expand lnd tls cert path

### DIFF
--- a/config.go
+++ b/config.go
@@ -294,6 +294,13 @@ func ValidateConfig(config *Config) error {
 		)
 	}
 
+	// Expand the lnd cert path, in case the user is specifying the home
+	// directory with ~ (which only the shell understands, not the low-level
+	// file system).
+	config.Lnd.TLSCertPath = lncfg.CleanAndExpandPath(
+		config.Lnd.TLSCertPath,
+	)
+
 	return nil
 }
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -32,6 +32,9 @@ This file tracks release notes for the faraday client.
 
 #### Bug Fixes
 
+* Fixed a config issue where the `--lnd.tlscertpath` flag wouldn't work if the
+  `~` shortcut for the home directory was used.
+
 #### Maintenance
 * Updated compile time dependencies of `lnd`, `grpc-gateway`, `protobuf` and
   `grpc`.


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/faraday/issues/141.

The lncfg.CleanAndExpandPath() call was missing for the lnd TLS
certificate path.

#### Pull Request Checklist
- [X] Update `release_notes.md` if your PR contains major features, breaking
  changes or bugfixes
- [ ] Update `MinLndVersion` if your PR uses new RPC methods or fields of `lnd`. 
