### PR TITLE
fiat: add support fo multiple granularities to coingecko

### DIFF
--- a/fiat/coingecko.go
+++ b/fiat/coingecko.go
@@ -18,27 +18,8 @@ const (
 	defaultCoinGeckoCurrency = "USD"
 )
 
-func newCoinGeckoAPI(g *Granularity) (*coinGeckoAPI, error) {
-	api := &coinGeckoAPI{
-		Granularity: GranularityHour,
-	}
-
-	if g != nil {
-		api.Granularity = *g
-	}
-
-	if api.Granularity != GranularityHour {
-		return nil, fmt.Errorf("coingecko only supports 1H " +
-			"granularity")
-	}
-
-	return api, nil
-}
-
 // coinGeckoAPI implements the fiatBackend interface.
-type coinGeckoAPI struct {
-	Granularity
-}
+type coinGeckoAPI struct{}
 
 type coinGeckoResponse struct {
 	Prices []coinGeckoPricePoint `json:"prices"`
@@ -50,8 +31,7 @@ type coinGeckoPricePoint []float64
 // historical price information. The api is expressed as a lag in days relative
 // to the current time, so we accept a lag value instead of a time range.
 func queryCoinGecko(lag int) ([]byte, error) {
-	queryURL := fmt.Sprintf("%v?vs_currency=usd&days=%v", coinGeckoURL,
-		lag)
+	queryURL := fmt.Sprintf("%v?vs_currency=usd&days=%v", coinGeckoURL, lag)
 
 	log.Debugf("coingecko url: %v", queryURL)
 
@@ -95,24 +75,14 @@ func parseCoinGeckoGata(data []byte) ([]*Price, error) {
 	return usdRecords, nil
 }
 
-// rawPriceData retrieves price information from coingecko's api for the given
-// time range.
-func (c *coinGeckoAPI) rawPriceData(ctx context.Context, start,
+// queryRange returns the rawPriceData for a given range. If start date is:
+// - Older than 90 days: it returns a 1 day granularity data.
+// - Within 90 days: it returns a 1 hour granularity data.
+//
+// NOTE: We add one day to our lag so that we always get at least one timestamp
+// that is before our start date.
+func (c *coinGeckoAPI) queryRange(ctx context.Context, now, start,
 	end time.Time) ([]*Price, error) {
-
-	// The coingecko api only supports historical price points relative
-	// to the present for the last 90 days (otherwise the granulaity of the
-	// price data changes). We need at least one timestamp before our start
-	// time so we limit the start point to 89 days, so that we can pad as
-	// needed, and then post-filter the data after fetching it.
-	now := time.Now()
-	cutoff := now.Add(time.Hour * 24 * 89 * -1)
-
-	if start.Before(cutoff) {
-		return nil, fmt.Errorf("coingecko only supports 1 hour "+
-			"granularity for the last 90 days, start time must be"+
-			"> %v", cutoff)
-	}
 
 	// We now calculate the number of days we need to lag from the present
 	// to cover our range. We add one day to our lag so that we always get
@@ -136,12 +106,84 @@ func (c *coinGeckoAPI) rawPriceData(ctx context.Context, start,
 	// start time, it's just the range from end->now that we need to filter.
 	// nolint: prealloc
 	var inRangeRecords []*Price
+
 	for _, record := range records {
 		if record.Timestamp.After(end) {
 			continue
 		}
 
 		inRangeRecords = append(inRangeRecords, record)
+	}
+
+	return inRangeRecords, nil
+}
+
+// timeRange represents the span of time that we will use to query the CoinGecko
+// API and filter the response.
+type timeRange struct {
+	start time.Time
+	end   time.Time
+}
+
+// apiRanges returns the time ranges that we need to query the CoinGecko API
+// for to get the best price data for the given time range.
+func (c *coinGeckoAPI) apiRanges(now, start, end time.Time) []timeRange {
+	// The coingecko api supports historical price points relative
+	// to the present for the last 90 days with granularity of 1 hour
+	// and granularity of 1 day for dates before that. We need at least one
+	// timestamp before our start time so we limit the start point to
+	// 89 days, so that we can pad as needed, and then post-filter the data
+	// after fetching it.
+	granularityBreakpoint := now.AddDate(0, 0, -89)
+
+	ranges := []timeRange{}
+
+	// Get data for dates older than 90 days with 1 day granularity.
+	if start.Before(granularityBreakpoint) {
+		// If our end date is before the granularity breakpoint, we
+		// can filter out all records after our end date.
+		cutoff := granularityBreakpoint
+		if end.Before(cutoff) {
+			cutoff = end
+		}
+
+		ranges = append(ranges, timeRange{start: start, end: cutoff})
+	}
+
+	// Get data for dates within 90 days with 1 hour granularity.
+	if end.After(granularityBreakpoint) {
+		// If our start date is after the granularity breakpoint, we
+		// can directly ask for dates after that.
+		cutoff := granularityBreakpoint
+		if start.After(cutoff) {
+			cutoff = start
+		}
+
+		ranges = append(ranges, timeRange{start: cutoff, end: end})
+	}
+
+	return ranges
+}
+
+// rawPriceData retrieves price information from coingecko's api for the given
+// time range.
+func (c *coinGeckoAPI) rawPriceData(ctx context.Context, start,
+	end time.Time) ([]*Price, error) {
+
+	now := time.Now()
+	inRangeRecords := []*Price{}
+
+	// The coingecko api has different granularity for different ranges so
+	// we query the api multiple times with the right spans.
+	for _, inRange := range c.apiRanges(now, start, end) {
+		records, err := c.queryRange(
+			ctx, now, inRange.start, inRange.end,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		inRangeRecords = append(inRangeRecords, records...)
 	}
 
 	return inRangeRecords, nil

--- a/fiat/coingecko_test.go
+++ b/fiat/coingecko_test.go
@@ -1,0 +1,74 @@
+package fiat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoinGeckoApiRanges tests that we can split up time spans into ranges with
+// different granularity.
+func TestCoinGeckoApiRanges(t *testing.T) {
+	// Freeze the current time.
+	now := time.Now()
+
+	tests := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+		want  []timeRange
+	}{
+		{
+			name:  "range in the last 90 days",
+			start: now.AddDate(0, 0, -89),
+			end:   now.Add(-time.Hour),
+			want: []timeRange{
+				{
+					start: now.AddDate(0, 0, -89),
+					end:   now.Add(-time.Hour),
+				},
+			},
+		},
+		{
+			name:  "range before the last 90 days",
+			start: now.AddDate(0, 0, -95),
+			end:   now.AddDate(0, 0, -90),
+			want: []timeRange{
+				{
+					start: now.AddDate(0, 0, -95),
+					end:   now.AddDate(0, 0, -90),
+				},
+			},
+		},
+		{
+			name:  "range between 95 days and yesterday",
+			start: now.AddDate(0, 0, -95),
+			end:   now.AddDate(0, 0, -1),
+			want: []timeRange{
+				{
+					start: now.AddDate(0, 0, -95),
+					end:   now.AddDate(0, 0, -89),
+				},
+				{
+					start: now.AddDate(0, 0, -89),
+					end:   now.AddDate(0, 0, -1),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &coinGeckoAPI{}
+
+			apiRanges := c.apiRanges(now, tc.start, tc.end)
+
+			require.Equal(t, tc.want, apiRanges)
+		})
+	}
+}

--- a/fiat/prices.go
+++ b/fiat/prices.go
@@ -93,12 +93,14 @@ func (cfg *PriceSourceConfig) validatePriceSourceConfig() error {
 		}
 
 	case CoinGeckoPriceBackend:
-		if cfg.Granularity != nil &&
-			*cfg.Granularity != GranularityHour {
-
-			return fmt.Errorf("%w: coingecko only provides hourly "+
-				"price granularity", errGranularityUnsupported)
+		if cfg.Granularity != nil {
+			return fmt.Errorf("%w: coingecko automatically "+
+				"provides hourly price granularity for the "+
+				"last 90 days and daily price granularity for "+
+				"dates older than that",
+				errGranularityUnsupported)
 		}
+
 	case CustomPriceBackend:
 		if len(cfg.PricePoints) == 0 {
 			return errPricePointsRequired
@@ -207,13 +209,8 @@ func NewPriceSource(cfg *PriceSourceConfig) (*PriceSource, error) {
 		}, nil
 
 	case CoinGeckoPriceBackend:
-		impl, err := newCoinGeckoAPI(cfg.Granularity)
-		if err != nil {
-			return nil, err
-		}
-
 		return &PriceSource{
-			impl: impl,
+			impl: &coinGeckoAPI{},
 		}, nil
 	}
 

--- a/fiat/prices_test.go
+++ b/fiat/prices_test.go
@@ -222,14 +222,7 @@ func TestValidatePriceSourceConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "coingecko hour granularity",
-			cfg: &PriceSourceConfig{
-				Backend:     CoinGeckoPriceBackend,
-				Granularity: &GranularityHour,
-			},
-		},
-		{
-			name: "coingecko wrong granularity",
+			name: "coingecko with granularity disallowed",
 			cfg: &PriceSourceConfig{
 				Backend:     CoinGeckoPriceBackend,
 				Granularity: &GranularityDay,

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.8-buster
+FROM golang:1.18.8
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache


### PR DESCRIPTION
The coingecko API automatically changes its granularity depending on how old is the pricing data you are asking for. For 90 days or less, it returns hourly entries while for any date 91 days or older it returns daily granularity.

To obtain the most exact results we should always make any reports in that 90 days window. That's why we currently do not support ranges that include dates older than 90 days.

In some case it may make sense to use daily data. This commit extends the current API to adapt the range and ensure that we get always the best possible data.

#### Pull Request Checklist
- [ ] Update `MinLndVersion` if your PR uses new RPC methods or fields of `lnd`. 
