### PR TITLE
frdrpc: add POST bindings for more complex calls

### DIFF
--- a/frdrpc/faraday.pb.gw.go
+++ b/frdrpc/faraday.pb.gw.go
@@ -117,6 +117,90 @@ func local_request_FaradayServer_OutlierRecommendations_0(ctx context.Context, m
 
 }
 
+func request_FaradayServer_OutlierRecommendations_1(ctx context.Context, marshaler runtime.Marshaler, client FaradayServerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq OutlierRecommendationsRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		e   int32
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["rec_request.metric"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rec_request.metric")
+	}
+
+	err = runtime.PopulateFieldFromPath(&protoReq, "rec_request.metric", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rec_request.metric", err)
+	}
+
+	e, err = runtime.Enum(val, CloseRecommendationRequest_Metric_value)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "rec_request.metric", err)
+	}
+
+	protoReq.RecRequest.Metric = CloseRecommendationRequest_Metric(e)
+
+	msg, err := client.OutlierRecommendations(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_FaradayServer_OutlierRecommendations_1(ctx context.Context, marshaler runtime.Marshaler, server FaradayServerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq OutlierRecommendationsRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		e   int32
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["rec_request.metric"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rec_request.metric")
+	}
+
+	err = runtime.PopulateFieldFromPath(&protoReq, "rec_request.metric", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rec_request.metric", err)
+	}
+
+	e, err = runtime.Enum(val, CloseRecommendationRequest_Metric_value)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "rec_request.metric", err)
+	}
+
+	protoReq.RecRequest.Metric = CloseRecommendationRequest_Metric(e)
+
+	msg, err := server.OutlierRecommendations(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 var (
 	filter_FaradayServer_ThresholdRecommendations_0 = &utilities.DoubleArray{Encoding: map[string]int{"rec_request": 0, "metric": 1}, Base: []int{1, 1, 1, 0}, Check: []int{0, 1, 2, 3}}
 )
@@ -203,6 +287,90 @@ func local_request_FaradayServer_ThresholdRecommendations_0(ctx context.Context,
 
 }
 
+func request_FaradayServer_ThresholdRecommendations_1(ctx context.Context, marshaler runtime.Marshaler, client FaradayServerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ThresholdRecommendationsRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		e   int32
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["rec_request.metric"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rec_request.metric")
+	}
+
+	err = runtime.PopulateFieldFromPath(&protoReq, "rec_request.metric", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rec_request.metric", err)
+	}
+
+	e, err = runtime.Enum(val, CloseRecommendationRequest_Metric_value)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "rec_request.metric", err)
+	}
+
+	protoReq.RecRequest.Metric = CloseRecommendationRequest_Metric(e)
+
+	msg, err := client.ThresholdRecommendations(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_FaradayServer_ThresholdRecommendations_1(ctx context.Context, marshaler runtime.Marshaler, server FaradayServerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ThresholdRecommendationsRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		e   int32
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["rec_request.metric"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rec_request.metric")
+	}
+
+	err = runtime.PopulateFieldFromPath(&protoReq, "rec_request.metric", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rec_request.metric", err)
+	}
+
+	e, err = runtime.Enum(val, CloseRecommendationRequest_Metric_value)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "could not parse path as enum value, parameter: %s, error: %v", "rec_request.metric", err)
+	}
+
+	protoReq.RecRequest.Metric = CloseRecommendationRequest_Metric(e)
+
+	msg, err := server.ThresholdRecommendations(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 var (
 	filter_FaradayServer_RevenueReport_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 )
@@ -231,6 +399,40 @@ func local_request_FaradayServer_RevenueReport_0(ctx context.Context, marshaler 
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_FaradayServer_RevenueReport_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.RevenueReport(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_FaradayServer_RevenueReport_1(ctx context.Context, marshaler runtime.Marshaler, client FaradayServerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RevenueReportRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.RevenueReport(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_FaradayServer_RevenueReport_1(ctx context.Context, marshaler runtime.Marshaler, server FaradayServerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RevenueReportRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -293,6 +495,40 @@ func local_request_FaradayServer_ExchangeRate_0(ctx context.Context, marshaler r
 
 }
 
+func request_FaradayServer_ExchangeRate_1(ctx context.Context, marshaler runtime.Marshaler, client FaradayServerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ExchangeRateRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.ExchangeRate(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_FaradayServer_ExchangeRate_1(ctx context.Context, marshaler runtime.Marshaler, server FaradayServerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ExchangeRateRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ExchangeRate(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 var (
 	filter_FaradayServer_NodeAudit_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 )
@@ -321,6 +557,40 @@ func local_request_FaradayServer_NodeAudit_0(ctx context.Context, marshaler runt
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_FaradayServer_NodeAudit_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.NodeAudit(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_FaradayServer_NodeAudit_1(ctx context.Context, marshaler runtime.Marshaler, client FaradayServerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq NodeAuditRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.NodeAudit(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_FaradayServer_NodeAudit_1(ctx context.Context, marshaler runtime.Marshaler, server FaradayServerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq NodeAuditRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -394,6 +664,29 @@ func RegisterFaradayServerHandlerServer(ctx context.Context, mux *runtime.ServeM
 
 	})
 
+	mux.Handle("POST", pattern_FaradayServer_OutlierRecommendations_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/frdrpc.FaradayServer/OutlierRecommendations", runtime.WithHTTPPathPattern("/v1/faraday/outliers/{rec_request.metric}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_FaradayServer_OutlierRecommendations_1(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_OutlierRecommendations_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_FaradayServer_ThresholdRecommendations_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -417,6 +710,29 @@ func RegisterFaradayServerHandlerServer(ctx context.Context, mux *runtime.ServeM
 
 	})
 
+	mux.Handle("POST", pattern_FaradayServer_ThresholdRecommendations_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/frdrpc.FaradayServer/ThresholdRecommendations", runtime.WithHTTPPathPattern("/v1/faraday/threshold/{rec_request.metric}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_FaradayServer_ThresholdRecommendations_1(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_ThresholdRecommendations_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_FaradayServer_RevenueReport_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -437,6 +753,29 @@ func RegisterFaradayServerHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 
 		forward_FaradayServer_RevenueReport_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_FaradayServer_RevenueReport_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/frdrpc.FaradayServer/RevenueReport", runtime.WithHTTPPathPattern("/v1/faraday/revenue"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_FaradayServer_RevenueReport_1(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_RevenueReport_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -486,6 +825,29 @@ func RegisterFaradayServerHandlerServer(ctx context.Context, mux *runtime.ServeM
 
 	})
 
+	mux.Handle("POST", pattern_FaradayServer_ExchangeRate_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/frdrpc.FaradayServer/ExchangeRate", runtime.WithHTTPPathPattern("/v1/faraday/exchangerate"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_FaradayServer_ExchangeRate_1(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_ExchangeRate_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_FaradayServer_NodeAudit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -506,6 +868,29 @@ func RegisterFaradayServerHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 
 		forward_FaradayServer_NodeAudit_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_FaradayServer_NodeAudit_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/frdrpc.FaradayServer/NodeAudit", runtime.WithHTTPPathPattern("/v1/faraday/nodeaudit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_FaradayServer_NodeAudit_1(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_NodeAudit_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -593,6 +978,26 @@ func RegisterFaradayServerHandlerClient(ctx context.Context, mux *runtime.ServeM
 
 	})
 
+	mux.Handle("POST", pattern_FaradayServer_OutlierRecommendations_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/frdrpc.FaradayServer/OutlierRecommendations", runtime.WithHTTPPathPattern("/v1/faraday/outliers/{rec_request.metric}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_FaradayServer_OutlierRecommendations_1(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_OutlierRecommendations_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_FaradayServer_ThresholdRecommendations_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -613,6 +1018,26 @@ func RegisterFaradayServerHandlerClient(ctx context.Context, mux *runtime.ServeM
 
 	})
 
+	mux.Handle("POST", pattern_FaradayServer_ThresholdRecommendations_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/frdrpc.FaradayServer/ThresholdRecommendations", runtime.WithHTTPPathPattern("/v1/faraday/threshold/{rec_request.metric}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_FaradayServer_ThresholdRecommendations_1(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_ThresholdRecommendations_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_FaradayServer_RevenueReport_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -630,6 +1055,26 @@ func RegisterFaradayServerHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 
 		forward_FaradayServer_RevenueReport_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_FaradayServer_RevenueReport_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/frdrpc.FaradayServer/RevenueReport", runtime.WithHTTPPathPattern("/v1/faraday/revenue"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_FaradayServer_RevenueReport_1(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_RevenueReport_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -673,6 +1118,26 @@ func RegisterFaradayServerHandlerClient(ctx context.Context, mux *runtime.ServeM
 
 	})
 
+	mux.Handle("POST", pattern_FaradayServer_ExchangeRate_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/frdrpc.FaradayServer/ExchangeRate", runtime.WithHTTPPathPattern("/v1/faraday/exchangerate"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_FaradayServer_ExchangeRate_1(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_ExchangeRate_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_FaradayServer_NodeAudit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -690,6 +1155,26 @@ func RegisterFaradayServerHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 
 		forward_FaradayServer_NodeAudit_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_FaradayServer_NodeAudit_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/frdrpc.FaradayServer/NodeAudit", runtime.WithHTTPPathPattern("/v1/faraday/nodeaudit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_FaradayServer_NodeAudit_1(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_FaradayServer_NodeAudit_1(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -719,15 +1204,25 @@ func RegisterFaradayServerHandlerClient(ctx context.Context, mux *runtime.ServeM
 var (
 	pattern_FaradayServer_OutlierRecommendations_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "faraday", "outliers", "rec_request.metric"}, ""))
 
+	pattern_FaradayServer_OutlierRecommendations_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "faraday", "outliers", "rec_request.metric"}, ""))
+
 	pattern_FaradayServer_ThresholdRecommendations_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "faraday", "threshold", "rec_request.metric"}, ""))
 
+	pattern_FaradayServer_ThresholdRecommendations_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "faraday", "threshold", "rec_request.metric"}, ""))
+
 	pattern_FaradayServer_RevenueReport_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "faraday", "revenue"}, ""))
+
+	pattern_FaradayServer_RevenueReport_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "faraday", "revenue"}, ""))
 
 	pattern_FaradayServer_ChannelInsights_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "faraday", "insights"}, ""))
 
 	pattern_FaradayServer_ExchangeRate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "faraday", "exchangerate"}, ""))
 
+	pattern_FaradayServer_ExchangeRate_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "faraday", "exchangerate"}, ""))
+
 	pattern_FaradayServer_NodeAudit_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "faraday", "nodeaudit"}, ""))
+
+	pattern_FaradayServer_NodeAudit_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "faraday", "nodeaudit"}, ""))
 
 	pattern_FaradayServer_CloseReport_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "faraday", "closereport"}, ""))
 )
@@ -735,15 +1230,25 @@ var (
 var (
 	forward_FaradayServer_OutlierRecommendations_0 = runtime.ForwardResponseMessage
 
+	forward_FaradayServer_OutlierRecommendations_1 = runtime.ForwardResponseMessage
+
 	forward_FaradayServer_ThresholdRecommendations_0 = runtime.ForwardResponseMessage
 
+	forward_FaradayServer_ThresholdRecommendations_1 = runtime.ForwardResponseMessage
+
 	forward_FaradayServer_RevenueReport_0 = runtime.ForwardResponseMessage
+
+	forward_FaradayServer_RevenueReport_1 = runtime.ForwardResponseMessage
 
 	forward_FaradayServer_ChannelInsights_0 = runtime.ForwardResponseMessage
 
 	forward_FaradayServer_ExchangeRate_0 = runtime.ForwardResponseMessage
 
+	forward_FaradayServer_ExchangeRate_1 = runtime.ForwardResponseMessage
+
 	forward_FaradayServer_NodeAudit_0 = runtime.ForwardResponseMessage
+
+	forward_FaradayServer_NodeAudit_1 = runtime.ForwardResponseMessage
 
 	forward_FaradayServer_CloseReport_0 = runtime.ForwardResponseMessage
 )

--- a/frdrpc/faraday.swagger.json
+++ b/frdrpc/faraday.swagger.json
@@ -119,6 +119,38 @@
         "tags": [
           "FaradayServer"
         ]
+      },
+      "post": {
+        "summary": "* frcli:\nGet fiat prices for btc.",
+        "description": "Example request:\nhttp://localhost:8466/v1/faraday/exchangerate",
+        "operationId": "FaradayServer_ExchangeRate2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/frdrpcExchangeRateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/frdrpcExchangeRateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "FaradayServer"
+        ]
       }
     },
     "/v1/faraday/insights": {
@@ -226,6 +258,38 @@
         "tags": [
           "FaradayServer"
         ]
+      },
+      "post": {
+        "summary": "*\nGet a report of your node's activity over a period.",
+        "description": "Example request:\nhttp://localhost:8466/v1/faraday/nodeaudit",
+        "operationId": "FaradayServer_NodeAudit2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/frdrpcNodeAuditResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/frdrpcNodeAuditRequest"
+            }
+          }
+        ],
+        "tags": [
+          "FaradayServer"
+        ]
       }
     },
     "/v1/faraday/outliers/{rec_request.metric}": {
@@ -278,6 +342,53 @@
             "required": false,
             "type": "number",
             "format": "float"
+          }
+        ],
+        "tags": [
+          "FaradayServer"
+        ]
+      },
+      "post": {
+        "summary": "* frcli: `outliers`\nGet close recommendations for currently open channels based on whether it is\nan outlier.",
+        "description": "Example request:\nhttp://localhost:8466/v1/faraday/outliers/REVENUE?rec_request.minimum_monitored=123",
+        "operationId": "FaradayServer_OutlierRecommendations2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/frdrpcCloseRecommendationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "rec_request.metric",
+            "description": "The data point base close recommendations on. Available options are:\nUptime: ratio of channel peer's uptime to the period they have been\nmonitored to.\nRevenue: the revenue that the channel has produced per block that its\nfunding transaction has been confirmed for.",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "UNKNOWN",
+              "UPTIME",
+              "REVENUE",
+              "INCOMING_VOLUME",
+              "OUTGOING_VOLUME",
+              "TOTAL_VOLUME"
+            ]
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/frdrpcOutlierRecommendationsRequest"
+            }
           }
         ],
         "tags": [
@@ -336,6 +447,38 @@
         "tags": [
           "FaradayServer"
         ]
+      },
+      "post": {
+        "summary": "* frcli: `revenue`\nGet a pairwise revenue report for a channel.",
+        "description": "Example request:\nhttp://localhost:8466/v1/faraday/revenue",
+        "operationId": "FaradayServer_RevenueReport2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/frdrpcRevenueReportResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/frdrpcRevenueReportRequest"
+            }
+          }
+        ],
+        "tags": [
+          "FaradayServer"
+        ]
       }
     },
     "/v1/faraday/threshold/{rec_request.metric}": {
@@ -388,6 +531,53 @@
             "required": false,
             "type": "number",
             "format": "float"
+          }
+        ],
+        "tags": [
+          "FaradayServer"
+        ]
+      },
+      "post": {
+        "summary": "* frcli: `threshold`\nGet close recommendations for currently open channels based whether they are\nbelow a set threshold.",
+        "description": "Example request:\nhttp://localhost:8466/v1/faraday/threshold/UPTIME?rec_request.minimum_monitored=123",
+        "operationId": "FaradayServer_ThresholdRecommendations2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/frdrpcCloseRecommendationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "rec_request.metric",
+            "description": "The data point base close recommendations on. Available options are:\nUptime: ratio of channel peer's uptime to the period they have been\nmonitored to.\nRevenue: the revenue that the channel has produced per block that its\nfunding transaction has been confirmed for.",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "UNKNOWN",
+              "UPTIME",
+              "REVENUE",
+              "INCOMING_VOLUME",
+              "OUTGOING_VOLUME",
+              "TOTAL_VOLUME"
+            ]
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/frdrpcThresholdRecommendationsRequest"
+            }
           }
         ],
         "tags": [
@@ -608,6 +798,34 @@
         }
       }
     },
+    "frdrpcExchangeRateRequest": {
+      "type": "object",
+      "properties": {
+        "timestamps": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uint64"
+          },
+          "description": "A set of timestamps for which we want the bitcoin price."
+        },
+        "granularity": {
+          "$ref": "#/definitions/frdrpcGranularity",
+          "description": "The level of granularity at which we want the bitcoin price to be quoted."
+        },
+        "fiat_backend": {
+          "$ref": "#/definitions/frdrpcFiatBackend",
+          "description": "The api to be used for fiat related queries."
+        },
+        "custom_prices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/frdrpcBitcoinPrice"
+          },
+          "description": "Custom price points to use if the CUSTOM FiatBackend option is set."
+        }
+      }
+    },
     "frdrpcExchangeRateResponse": {
       "type": "object",
       "properties": {
@@ -648,6 +866,47 @@
       "default": "UNKNOWN_GRANULARITY",
       "description": "Granularity describes the aggregation level at which the Bitcoin price should\nbe queried. Note that setting lower levels of granularity may require more\nqueries to the fiat backend."
     },
+    "frdrpcNodeAuditRequest": {
+      "type": "object",
+      "properties": {
+        "start_time": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The unix time from which to produce the report, inclusive."
+        },
+        "end_time": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The unix time until which to produce the report, exclusive."
+        },
+        "disable_fiat": {
+          "type": "boolean",
+          "description": "Set to generate a report without conversion to fiat. If set, fiat values\nwill display as 0."
+        },
+        "granularity": {
+          "$ref": "#/definitions/frdrpcGranularity",
+          "description": "The level of granularity at which we wish to produce fiat prices."
+        },
+        "custom_categories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/frdrpcCustomCategory"
+          },
+          "description": "An optional set of custom categories which can be used to identify bespoke\ncategories in the report. Each category must have a unique name, and may not\nhave common identifier regexes. Transactions that are matched to these\ncategories report the category name in the CustomCategory field."
+        },
+        "fiat_backend": {
+          "$ref": "#/definitions/frdrpcFiatBackend",
+          "description": "The api to be used for fiat related queries."
+        },
+        "custom_prices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/frdrpcBitcoinPrice"
+          },
+          "description": "Custom price points to use if the CUSTOM FiatBackend option is set."
+        }
+      }
+    },
     "frdrpcNodeAuditResponse": {
       "type": "object",
       "properties": {
@@ -657,6 +916,20 @@
             "$ref": "#/definitions/frdrpcReportEntry"
           },
           "description": "On chain reports for the period queried."
+        }
+      }
+    },
+    "frdrpcOutlierRecommendationsRequest": {
+      "type": "object",
+      "properties": {
+        "rec_request": {
+          "$ref": "#/definitions/frdrpcCloseRecommendationRequest",
+          "description": "The parameters that are common to all close recommendations."
+        },
+        "outlier_multiplier": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of inter-quartile ranges a value needs to be beneath the lower\nquartile/ above the upper quartile to be considered a lower/upper outlier.\nLower values will be more aggressive in recommending channel closes, and\nupper values will be more conservative. Recommended values are 1.5 for\naggressive recommendations and 3 for conservative recommendations."
         }
       }
     },
@@ -774,6 +1047,28 @@
         }
       }
     },
+    "frdrpcRevenueReportRequest": {
+      "type": "object",
+      "properties": {
+        "chan_points": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The funding transaction outpoints for the channels to generate a revenue\nreport for. If this is empty, it will be generated for all open and closed\nchannels. Channel funding points should be expressed with the format\nfundingTxID:outpoint."
+        },
+        "start_time": {
+          "type": "string",
+          "format": "uint64",
+          "description": "Start time is beginning of the range over which the report will be\ngenerated, expressed as unix epoch offset in seconds."
+        },
+        "end_time": {
+          "type": "string",
+          "format": "uint64",
+          "description": "End time is end of the range over which the report will be\ngenerated, expressed as unix epoch offset in seconds."
+        }
+      }
+    },
     "frdrpcRevenueReportResponse": {
       "type": "object",
       "properties": {
@@ -783,6 +1078,20 @@
             "$ref": "#/definitions/frdrpcRevenueReport"
           },
           "description": "Reports is a set of pairwise revenue report generated for the channel(s)\nover the period specified."
+        }
+      }
+    },
+    "frdrpcThresholdRecommendationsRequest": {
+      "type": "object",
+      "properties": {
+        "rec_request": {
+          "$ref": "#/definitions/frdrpcCloseRecommendationRequest",
+          "description": "The parameters that are common to all close recommendations."
+        },
+        "threshold_value": {
+          "type": "number",
+          "format": "float",
+          "description": "The threshold that recommendations will be calculated based on.\nFor uptime: ratio of uptime to observed lifetime beneath which channels\nwill be recommended for closure.\n\nFor revenue: revenue per block that capital has been committed to the\nchannel beneath which channels will be recommended for closure. This\nvalue is provided per block so that channels that have been open for\ndifferent periods of time can be compared.\n\nFor incoming volume: The incoming volume per block that capital has\nbeen committed to the channel beneath which channels will be recommended\nfor closure. This value is provided per block so that channels that have\nbeen open for different periods of time can be compared.\n\nFor outgoing volume: The outgoing volume per block that capital has been\ncommitted to the channel beneath which channels will be recommended for\nclosure. This value is provided per block so that channels that have been\nopen for different periods of time can be compared.\n\nFor total volume: The total volume per block that capital has been\ncommitted to the channel beneath which channels will be recommended for\nclosure. This value is provided per block so that channels that have been\nopen for different periods of time can be compared."
         }
       }
     },

--- a/frdrpc/faraday.yaml
+++ b/frdrpc/faraday.yaml
@@ -6,15 +6,30 @@ http:
     # rpc.proto
     - selector: frdrpc.FaradayServer.OutlierRecommendations
       get: "/v1/faraday/outliers/{rec_request.metric}"
+      additional_bindings:
+        - post: "/v1/faraday/outliers/{rec_request.metric}"
+          body: "*"
     - selector: frdrpc.FaradayServer.ThresholdRecommendations
       get: "/v1/faraday/threshold/{rec_request.metric}"
+      additional_bindings:
+        - post: "/v1/faraday/threshold/{rec_request.metric}"
+          body: "*"
     - selector: frdrpc.FaradayServer.RevenueReport
       get: "/v1/faraday/revenue"
+      additional_bindings:
+        - post: "/v1/faraday/revenue"
+          body: "*"
     - selector: frdrpc.FaradayServer.ChannelInsights
       get: "/v1/faraday/insights"
     - selector: frdrpc.FaradayServer.ExchangeRate
       get: "/v1/faraday/exchangerate"
+      additional_bindings:
+        - post: "/v1/faraday/exchangerate"
+          body: "*"
     - selector: frdrpc.FaradayServer.NodeAudit
       get: "/v1/faraday/nodeaudit"
+      additional_bindings:
+        - post: "/v1/faraday/nodeaudit"
+          body: "*"
     - selector: frdrpc.FaradayServer.CloseReport
       get: "/v1/faraday/closereport"


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/faraday/issues/163.

Using GET mappings for REST means we have to place every parameter in the URL query. This is not very convenient if there are many parameters. But even worse, some types like arrays/slices aren't supported in query parameters and map types are very awkward to use.
So we add POST mappings for the calls that have many or more complex request parameters.

#### Pull Request Checklist
- [ ] Update `MinLndVersion` if your PR uses new RPC methods or fields of `lnd`. 
