### PR TITLE
Upgrade go to 1.19 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.8-alpine as builder
+FROM golang:1.19-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.


### PR DESCRIPTION
Currently docker build fails with:
```sh
$ docker build .
...
github.com/lightningnetwork/lnd/discovery
# github.com/lightningnetwork/lnd/discovery
/go/pkg/mod/github.com/lightningnetwork/lnd@v0.16.0-beta/discovery/gossiper.go:644:15: undefined: atomic.Uint64
note: module requires Go 1.19
make: *** [Makefile:55: build] Error 2
The command '/bin/sh -c apk add --no-cache --update alpine-sdk     git     make     gcc &&  cd /go/src/github.com/lightninglabs/faraday &&  make &&  make install' returned a non-zero code: 2
```

#### Pull Request Checklist
- [x] Update `MinLndVersion` if your PR uses new RPC methods or fields of `lnd`. 
