### PR TITLE
Include outgoing payment description in audit memo

### DIFF
--- a/accounting/entries.go
+++ b/accounting/entries.go
@@ -401,11 +401,18 @@ func paymentReference(sequenceNumber uint64, preimage lntypes.Preimage) string {
 
 // paymentNote creates a note for payments from our node.
 // nolint: interfacer
-func paymentNote(dest *route.Vertex) string {
-	if dest == nil {
-		return ""
+func paymentNote(dest *route.Vertex, memo *string) string {
+	var notes []string
+
+	if memo != nil && *memo != "" {
+		notes = append(notes, fmt.Sprintf("memo: %v", *memo))
 	}
-	return dest.String()
+
+	if dest != nil {
+		notes = append(notes, fmt.Sprintf("destination: %v", dest))
+	}
+
+	return strings.Join(notes, "/")
 }
 
 // paymentEntry creates an entry for an off chain payment, including fee entries
@@ -432,7 +439,7 @@ func paymentEntry(payment paymentInfo, paidToSelf bool,
 
 	// Create a note for our payment. Since we have already checked that our
 	// payment is settled, we will not have a nil preimage.
-	note := paymentNote(payment.destination)
+	note := paymentNote(payment.destination, payment.description)
 	ref := paymentReference(payment.SequenceNumber, *payment.Preimage)
 
 	// Payment values are expressed as positive values over rpc, but they

--- a/accounting/entries_test.go
+++ b/accounting/entries_test.go
@@ -83,10 +83,6 @@ var (
 		Tx:        &wire.MsgTx{},
 	}
 
-	paymentRequest = "lnbcrt10n1p0t6nmypp547evsfyrakg0nmyw59ud9cegkt99yccn5nnp4suq3ac4qyzzgevsdqqcqzpgsp54hvffpajcyddm20k3ptu53930425hpnv8m06nh5jrd6qhq53anrq9qy9qsqphhzyenspf7kfwvm3wyu04fa8cjkmvndyexlnrmh52huwa4tntppjmak703gfln76rvswmsx2cz3utsypzfx40dltesy8nj64ttgemgqtwfnj9"
-
-	invoiceMemo = "memo"
-
 	invoiceAmt = lnwire.MilliSatoshi(300)
 
 	invoiceOverpaidAmt = lnwire.MilliSatoshi(400)
@@ -112,7 +108,7 @@ var (
 
 	paymentTime = time.Unix(1590399649, 0)
 
-	paymentHash = "11f414479f0a0c2762492c71c58dded5dce99d56d65c3fa523f73513605bebb3"
+	paymentHash = "0001020304050607080900010203040506070809000102030405060708090102"
 	pmtHash, _  = lntypes.MakeHashFromStr(paymentHash)
 
 	paymentPreimage = "adfef20b24152accd4ed9a05257fb77203d90a8bbbe6d4069a75c5320f0538d9"
@@ -134,11 +130,13 @@ var (
 		Fee:            lnwire.MilliSatoshi(paymentFeeMsat),
 		Htlcs:          []*lnrpc.HTLCAttempt{{}},
 		SequenceNumber: uint64(paymentIndex),
+		PaymentRequest: paymentRequest,
 	}
 
 	payInfo = paymentInfo{
 		Payment:     payment,
 		destination: &otherPubkey,
+		description: &invoiceMemo,
 		settleTime:  paymentTime,
 	}
 
@@ -758,7 +756,7 @@ func TestPaymentEntry(t *testing.T) {
 			FiatValue: fiat.MsatToFiat(mockBTCPrice.Price, amtMsat),
 			TxID:      paymentHash,
 			Reference: paymentRef,
-			Note:      paymentNote(&otherPubkey),
+			Note:      paymentNote(&otherPubkey, &invoiceMemo),
 			Type:      EntryTypePayment,
 			OnChain:   false,
 			Credit:    false,
@@ -773,7 +771,7 @@ func TestPaymentEntry(t *testing.T) {
 			FiatValue: fiat.MsatToFiat(mockBTCPrice.Price, feeMsat),
 			TxID:      paymentHash,
 			Reference: FeeReference(paymentRef),
-			Note:      paymentNote(&otherPubkey),
+			Note:      paymentNote(&otherPubkey, &invoiceMemo),
 			Type:      EntryTypeFee,
 			OnChain:   false,
 			Credit:    false,

--- a/accounting/filter_test.go
+++ b/accounting/filter_test.go
@@ -378,6 +378,7 @@ func decode(toSelf bool) func(_ string) (*lndclient.PaymentRequest,
 
 		return &lndclient.PaymentRequest{
 			Destination: pubkey,
+			Description: invoiceMemo,
 		}, nil
 	}
 }
@@ -437,35 +438,39 @@ func TestPaymentHtlcDestination(t *testing.T) {
 	}
 }
 
-// TestPaymentRequestDestination tests getting of payment destinations from our
+// TestPaymentRequestDestination tests getting of payment details from our
 // payment request.
-func TestPaymentRequestDestination(t *testing.T) {
+func TestPaymentRequestDetails(t *testing.T) {
 	tests := []struct {
 		name           string
 		paymentRequest string
 		decode         decodePaymentRequest
-		dest           *route.Vertex
+		destination    *route.Vertex
+		description    *string
 		err            error
 	}{
 		{
 			name:           "no payment request",
 			decode:         decode(true),
 			paymentRequest: "",
-			dest:           nil,
+			destination:    nil,
+			description:    nil,
 			err:            errNoPaymentRequest,
 		},
 		{
 			name:           "to self",
 			decode:         decode(true),
 			paymentRequest: paymentRequest,
-			dest:           &ourPubKey,
+			destination:    &ourPubKey,
+			description:    &invoiceMemo,
 			err:            nil,
 		},
 		{
 			name:           "not to self",
 			decode:         decode(false),
 			paymentRequest: paymentRequest,
-			dest:           &otherPubkey,
+			destination:    &otherPubkey,
+			description:    &invoiceMemo,
 			err:            nil,
 		},
 	}
@@ -476,11 +481,13 @@ func TestPaymentRequestDestination(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			dest, err := paymentRequestDestination(
+			destination, description, err := paymentRequestDetails(
 				test.paymentRequest, test.decode,
 			)
+
 			require.Equal(t, test.err, err)
-			require.Equal(t, test.dest, dest)
+			require.Equal(t, test.destination, destination)
+			require.Equal(t, test.description, description)
 		})
 	}
 }

--- a/accounting/off_chain_test.go
+++ b/accounting/off_chain_test.go
@@ -24,6 +24,9 @@ var (
 	paymentHash2 = "a5530c5930b9eb7ea4284bcff39da52c6bca3103fc790749eb632911edc7143b"
 	hash2, _     = lntypes.MakeHashFromStr(paymentHash2)
 
+	paymentRequest = "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp"
+	invoiceMemo    = "1 cup coffee"
+
 	hopToUs = &lnrpc.Hop{
 		PubKey: ourPK,
 	}


### PR DESCRIPTION
Include invoice memo in audit nodes for outgoing payments that pay to an invoice. This allows for more options to correlate money movements during reconciliation.

Context: Improves ability to reconcile payments related to peerswaps. See https://github.com/ElementsProject/peerswap/issues/254 for additional context.

This pull request involves changes to the `accounting` package, specifically the `entries.go`, `entries_test.go`, `filter.go`, and `filter_test.go` files. The changes primarily involve the addition of a `description` field to the `paymentInfo` struct and the modification of the `paymentNote` function to include the `memo` field. The changes also involve modifications to the `paymentEntry` and `paymentRequestDetails` functions to accommodate the new `description` field.

Fix https://github.com/lightninglabs/faraday/issues/181

Changes to `entries.go` and `entries_test.go`:

* `func paymentReference(sequenceNumber uint64, preimage lntypes.Preimage) string {`: Modified the `paymentNote` function to include a `memo` field and to append the `memo` and `dest` fields to a `notes` slice. The function now returns a string joined by the `notes` slice elements instead of just the `dest` string.
* `func paymentEntry(payment paymentInfo, paidToSelf bool,`: Modified the `paymentNote` function call in the `paymentEntry` function to include the `payment.description` field.
* [`func TestPaymentEntry(t *testing.T) {`](diffhunk://#diff-3162c2e2d764199457c98cf2788a4e46ced2105b67eddb8af995c6cd13e61f8fL761-R759): Modified the `paymentNote` function call in the `TestPaymentEntry` test function to include the `&invoiceMemo` field. [[1]](diffhunk://#diff-3162c2e2d764199457c98cf2788a4e46ced2105b67eddb8af995c6cd13e61f8fL761-R759) [[2]](diffhunk://#diff-3162c2e2d764199457c98cf2788a4e46ced2105b67eddb8af995c6cd13e61f8fL776-R774)

Changes to `filter.go` and `filter_test.go`:

* [`type paymentInfo struct {`](diffhunk://#diff-0b49c6914e8b2658a934a8474133d297cb3ee0e68ce24b7d61d32e9922e518fcL112-R121): Added a `description` field to the `paymentInfo` struct.
* `func preProcessPayments(payments []lndclient.Payment,`: Modified the `preProcessPayments` function to include the `description` field in the `paymentInfo` struct.
* `func paymentRequestDetails(paymentRequest string, decode decodePaymentRequest) (*route.Vertex, *string, error) {`: Renamed the `paymentRequestDestination` function to `paymentRequestDetails` and modified it to return a `description` field in addition to the `destination` field.
* [`func TestPaymentRequestDestination(t *testing.T) {`](diffhunk://#diff-eab7db6872cddeafbec44ce2a4d2f5b6e5af13c8b7b9f7d3708359f076ee840cL440-R473): Renamed the `TestPaymentRequestDestination` test function to `TestPaymentRequestDetails` and modified it to test the `description` field in addition to the `destination` field. [[1]](diffhunk://#diff-eab7db6872cddeafbec44ce2a4d2f5b6e5af13c8b7b9f7d3708359f076ee840cL440-R473) [[2]](diffhunk://#diff-eab7db6872cddeafbec44ce2a4d2f5b6e5af13c8b7b9f7d3708359f076ee840cL479-R490)
