### PR TITLE
chore: adds github actions to push faraday docker images to docker hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker image build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: lightninglabs/gh-actions/setup-qemu-action@2021.01.25.00
+
+      - name: Set up Docker buildx
+        uses: lightninglabs/gh-actions/setup-buildx-action@2021.01.25.00
+
+      - name: Login to DockerHub
+        uses: lightninglabs/gh-actions/login-action@2021.01.25.00
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_API_KEY }}
+
+      - name: Set env
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          DOCKER_REPO_DEFAULT=${{secrets.DOCKER_REPO}}
+          echo "DOCKER_REPO=${DOCKER_REPO_DEFAULT:-lightninglabs/faraday}" >> $GITHUB_ENV
+
+      - name: Build and push image
+        id: docker_build
+        uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: "${{ env.DOCKER_REPO }}:${{ env.RELEASE_VERSION }}"
+          build-args: checkout=${{ env.RELEASE_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
### What does this PR do?
- Closes #175 

## How should this be tested?
To validate the effectiveness of the newly integrated GitHub Action for automating Docker image pushes to Docker Hub upon a new release, follow these steps:

1. Trigger a New Release:

Navigate to the repository's 'Releases' section.
Create a new release. You can do this by tagging a specific commit or using the repository's latest commit. Ensure that the release process mimics the standard release procedure for this repository.

2.Verify GitHub Action Execution:

Once the release is created, go to the 'Actions' tab in the GitHub repository.
You should see a new workflow run initiated by the release action. This workflow corresponds to the GitHub Action we have added for Docker image automation.

3. Check Workflow Logs:

Click on the workflow run to view its details.
Review the logs to ensure that the GitHub Action executed correctly without any errors. Pay special attention to the steps where the Docker image is built and pushed to Docker Hub.

4. Inspect Docker Hub Repository:

Go to the Docker Hub repository linked to this GitHub repository.
Verify that a new Docker image has been pushed successfully. Ensure the image tag matches the release version/tag created in step 1.

5.Optional: Pull and Run the Docker Image:

As an additional verification step, you can pull the newly pushed Docker image from Docker Hub to your local machine using docker pull <image_name>:<tag>.
Run the Docker image locally to ensure it's functioning as expected.

Please note that this GitHub Action is configured to trigger only on new releases. Any direct pushes or merged PRs to the main branch will not activate this action unless they are part of a release process.

Also note that the repo admin would need to create the docker hub and add the required environment variables

#### Pull Request Checklist
- [ ] Update `MinLndVersion` if your PR uses new RPC methods or fields of `lnd`. 
