### PR TITLE
config+frcli: fix macaroon & tls cert path parsing

### DIFF
--- a/cmd/frcli/utils.go
+++ b/cmd/frcli/utils.go
@@ -159,12 +159,23 @@ func extractPathArgs(ctx *cli.Context) (string, string, error) {
 	if faradayDir != faraday.FaradayDirBase ||
 		networkStr != faraday.DefaultNetwork {
 
-		tlsCertPath = filepath.Join(
-			faradayDir, networkStr, faraday.DefaultTLSCertFilename,
-		)
-		macPath = filepath.Join(
-			faradayDir, networkStr, faraday.DefaultMacaroonFilename,
-		)
+		// Only overwrite the tls cert path if the user has not
+		// explicitly defined it.
+		if !ctx.GlobalIsSet(tlsCertFlag.Name) {
+			tlsCertPath = filepath.Join(
+				faradayDir, networkStr,
+				faraday.DefaultTLSCertFilename,
+			)
+		}
+
+		// Only overwrite the macaroon path if the user has not
+		// explicitly defined it.
+		if !ctx.GlobalIsSet(macaroonPathFlag.Name) {
+			macPath = filepath.Join(
+				faradayDir, networkStr,
+				faraday.DefaultMacaroonFilename,
+			)
+		}
 	}
 
 	return tlsCertPath, macPath, nil

--- a/config.go
+++ b/config.go
@@ -192,6 +192,10 @@ func ValidateConfig(config *Config) error {
 	config.TLSKeyPath = lncfg.CleanAndExpandPath(config.TLSKeyPath)
 	config.MacaroonPath = lncfg.CleanAndExpandPath(config.MacaroonPath)
 
+	// Before adding the network namespace below, check if the user has
+	// overwritten the default faraday directory.
+	faradayDirSet := config.FaradayDir != FaradayDirBase
+
 	// Append the network type to faraday directory so they are "namespaced"
 	// per network.
 	config.FaradayDir = filepath.Join(config.FaradayDir, config.Network)
@@ -205,7 +209,6 @@ func ValidateConfig(config *Config) error {
 	// values, make sure that they are not set when faraday dir is set. We
 	// fail hard here rather than overwriting and potentially confusing the
 	// user.
-	faradayDirSet := config.FaradayDir != FaradayDirBase
 	if faradayDirSet {
 		tlsCertPathSet := config.TLSCertPath != DefaultTLSCertPath
 		tlsKeyPathSet := config.TLSKeyPath != DefaultTLSKeyPath


### PR DESCRIPTION
1) Ensure that the `faradayDirSet` boolean is accurately set. Otherwise it is always true & so will always result in errors when the user provides their own macaroon path when they dont set the faraday dir.
2) For frcli, ensure that the tls cert & macaroon paths are only overridden with the correct network namespace if the user has not explicitly defined them

Fixes #191

