### PR TITLE
frdrpcserver: update rpcserver-max-recv-size

### DIFF
--- a/frdrpcserver/rpcserver.go
+++ b/frdrpcserver/rpcserver.go
@@ -56,8 +56,8 @@ var (
 	)
 
 	// maxMsgRecvSize is the largest message our REST proxy will receive. We
-	// set this to 400MiB atm.
-	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(400 * 1024 * 1024)
+	// set this to 600MiB atm.
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(600 * 1024 * 1024)
 
 	// maxInvoiceQueries is the maximum number of invoices we request from
 	// lnd at a time.


### PR DESCRIPTION
#### References:
- Related issue: [#177 ResourceExhausted error while running the Node Audit](https://github.com/lightninglabs/faraday/issues/177)

#### Change(s):
The change for this PR increases the gRPC message size limit from 400MiB to 600MiB.  We encountered a ResourceExhausted error while running the NodeAudit report, particularly on nodes with a high number of on-chain transactions.

```
{'code': 8, 'message': 'grpc: received message larger than max (419942095 vs. 419430400)', 'details': []}
```
This error could be  due to the gRPC message size exceeding the current 400MiB limit. In LND, this limit is configurable and can be adjusted by the calling client, but Faraday currently lacks this configurability.  This is a temporary fix, with issue 177 recommending a long-term solution involving the implementation of pagination for the calls.