### PR TITLE
frdrpcserver: update rpcserver-max-recv-size

### DIFF
--- a/cmd/frcli/utils.go
+++ b/cmd/frcli/utils.go
@@ -34,8 +34,8 @@ import (
 
 var (
 	// maxMsgRecvSize is the largest message our client will receive. We
-	// set this to 200MiB atm.
-	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 200)
+	// set this to 800MiB atm.
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(800 * 1024 * 1024)
 
 	// defaultMacaroonTimeout is the default macaroon timeout in seconds
 	// that we set when sending it over the line.

--- a/frdrpcserver/rpcserver.go
+++ b/frdrpcserver/rpcserver.go
@@ -57,8 +57,8 @@ var (
 	)
 
 	// maxMsgRecvSize is the largest message our REST proxy will receive. We
-	// set this to 850MiB atm.
-	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(850 * 1024 * 1024)
+	// set this to 800MiB atm.
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(800 * 1024 * 1024)
 
 	// maxInvoiceQueries is the maximum number of invoices we request from
 	// lnd at a time.

--- a/frdrpcserver/rpcserver.go
+++ b/frdrpcserver/rpcserver.go
@@ -57,8 +57,8 @@ var (
 	)
 
 	// maxMsgRecvSize is the largest message our REST proxy will receive. We
-	// set this to 600MiB atm.
-	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(600 * 1024 * 1024)
+	// set this to 850MiB atm.
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(850 * 1024 * 1024)
 
 	// maxInvoiceQueries is the maximum number of invoices we request from
 	// lnd at a time.


### PR DESCRIPTION
### References:
- Related issue: https://github.com/lightninglabs/faraday/issues/177
- Related PR: https://github.com/lightninglabs/faraday/pull/195

### Change(s):

The change for this PR increases the gRPC message size limit from 600MiB to 800MiB. Similar to the PR above, we encountered a ResourceExhausted error while running the NodeAudit report, particularly on nodes with a high number of on-chain transactions.

```
Exception: Unexpected response from Faraday API: {'code': 8, 'message': 'grpc: received message larger than max (630803848 vs. 629145600)', 'details': []}
```

This error could be due to the gRPC message size exceeding the current 600MiB limit. In LND, this limit is configurable and can be adjusted by the calling client, but Faraday currently lacks this configurability. This is a temporary fix, with issue 177 recommending a long-term solution involving the implementation of pagination for the calls.

The gRPC message size limit is being increased to 800 MiB to accommodate large payloads generated by specific use cases, such as transaction histories or detailed audit reports. Trying to strike a balance between supporting current operational needs and maintaining resource efficiency.

