### PR TITLE
docs: clarify bitcoind/btcd connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ To connect Faraday to btcd:
 --bitcoin.tlspath={path to btcd cert}
 ```
 
+Notes on the `bitcoin.*` options:
+
+- `--bitcoin.host` must include the port of the node's **RPC interface** —
+  there is no default port. Common bitcoind RPC ports: `8332` (mainnet),
+  `18332` (testnet), `38332` (signet), `18443` (regtest).
+- `--bitcoin.user` and `--bitcoin.password` are the node's **RPC
+  credentials** — for bitcoind that is `rpcuser`/`rpcpassword`, or the
+  user and password behind an `rpcauth` entry.
+- The connection is **established lazily**, when an endpoint first needs
+  it — not on startup. A misconfigured connection therefore tends to
+  surface later, as an error such as `status code: 401` when running
+  `closereport` or an `audit` over a period that contains channel closes.
+  If you see such an error, verify the `bitcoin.*` values by querying the
+  node directly with the same credentials, e.g.:
+
+  ```shell
+  curl --user {user}:{password} --data-binary \
+      '{"jsonrpc":"1.0","method":"getblockchaininfo","params":[]}' \
+      http://{host:port}/
+  ```
+
 #### RPCServer
 Faraday serves requests over grpc by default on `localhost:8465`. This default can be overwritten:
 ```text

--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ To connect Faraday to btcd:
 Notes on the `bitcoin.*` options:
 
 - `--bitcoin.host` must include the port of the node's **RPC interface** —
-  there is no default port. Common bitcoind RPC ports: `8332` (mainnet),
-  `18332` (testnet), `38332` (signet), `18443` (regtest).
+  no port is appended automatically when a custom host is set. (If the
+  option is omitted entirely, it defaults to `localhost:8332`.) Common
+  bitcoind RPC ports: `8332` (mainnet), `18332` (testnet), `38332`
+  (signet), `18443` (regtest).
 - `--bitcoin.user` and `--bitcoin.password` are the node's **RPC
   credentials** — for bitcoind that is `rpcuser`/`rpcpassword`, or the
   user and password behind an `rpcauth` entry.

--- a/chain/client.go
+++ b/chain/client.go
@@ -20,7 +20,7 @@ type BitcoinClient interface {
 // BitcoinConfig defines exported config options for the connection to the
 // btcd/bitcoind backend.
 type BitcoinConfig struct {
-	Host         string `long:"host" description:"host:port of the bitcoind/btcd RPC interface; the port must be included explicitly. Common bitcoind RPC ports: 8332 (mainnet), 18332 (testnet), 38332 (signet), 18443 (regtest)"`
+	Host         string `long:"host" description:"host:port of the bitcoind/btcd RPC interface; no port is appended automatically, so a custom host must include it explicitly (defaults to localhost:8332 if unset). Common bitcoind RPC ports: 8332 (mainnet), 18332 (testnet), 38332 (signet), 18443 (regtest)"`
 	User         string `long:"user" description:"RPC user of the bitcoind/btcd instance (for bitcoind: rpcuser, or the user of an rpcauth entry)"`
 	Password     string `long:"password" description:"RPC password of the bitcoind/btcd instance (for bitcoind: rpcpassword, or the password behind an rpcauth entry)"`
 	HTTPPostMode bool   `long:"httppostmode" description:"Use HTTP POST mode? bitcoind only supports this mode"`

--- a/chain/client.go
+++ b/chain/client.go
@@ -20,9 +20,9 @@ type BitcoinClient interface {
 // BitcoinConfig defines exported config options for the connection to the
 // btcd/bitcoind backend.
 type BitcoinConfig struct {
-	Host         string `long:"host" description:"host:port of the bitcoind/btcd instance address"`
-	User         string `long:"user" description:"bitcoind/btcd user name"`
-	Password     string `long:"password" description:"bitcoind/btcd password"`
+	Host         string `long:"host" description:"host:port of the bitcoind/btcd RPC interface; the port must be included explicitly. Common bitcoind RPC ports: 8332 (mainnet), 18332 (testnet), 38332 (signet), 18443 (regtest)"`
+	User         string `long:"user" description:"RPC user of the bitcoind/btcd instance (for bitcoind: rpcuser, or the user of an rpcauth entry)"`
+	Password     string `long:"password" description:"RPC password of the bitcoind/btcd instance (for bitcoind: rpcpassword, or the password behind an rpcauth entry)"`
 	HTTPPostMode bool   `long:"httppostmode" description:"Use HTTP POST mode? bitcoind only supports this mode"`
 	UseTLS       bool   `long:"usetls" description:"Use TLS to connect? bitcoind only supports non-TLS connections"`
 	TLSPath      string `long:"tlspath" description:"Path to btcd tls certificate, bitcoind only supports non-TLS connections"`

--- a/config.go
+++ b/config.go
@@ -148,7 +148,7 @@ type Config struct { //nolint:maligned
 	FaradayDir string `long:"faradaydir" description:"The directory for all of faraday's data. If set, this option overwrites --macaroonpath, --tlscertpath and --tlskeypath."`
 
 	// ChainConn specifies whether to attempt connecting to a bitcoin backend.
-	ChainConn bool `long:"connect_bitcoin" description:"Whether to attempt to connect to a backing bitcoin node. Some endpoints will not be available if this option is not enabled."`
+	ChainConn bool `long:"connect_bitcoin" description:"Whether to attempt to connect to a backing bitcoin node. Some endpoints will not be available if this option is not enabled. Note that the connection is only established once an endpoint needs it, so a misconfigured connection (see the bitcoin.* options) may only surface as an error at request time rather than on startup."`
 
 	ShowVersion bool `long:"version" description:"Display version information and exit"`
 


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #176, per the direction there to "update the flag/config description a bit better, at least for the host/port part".

Both confusions reported in that thread are addressed:

1. **Missing port / which port** — `--bitcoin.host` now states the port must be included explicitly and lists the common bitcoind RPC ports per network (8332 mainnet / 18332 testnet / 38332 signet / 18443 regtest). `--bitcoin.user` / `--bitcoin.password` now say they are the node's **RPC credentials** (`rpcuser`/`rpcpassword` or an `rpcauth` entry).
2. **Lazy connection made debugging hard** — the connection is only established when an endpoint needs the chain, so a misconfiguration surfaces later as e.g. `status code: 401` on `closereport`, or on an `audit` over a period containing channel closes. The `--connect_bitcoin` description and the README chain-backend section now say this explicitly, and the README shows how to verify the credentials against the node directly with `curl`.

## Changes

- `chain/client.go`: `bitcoin.host` / `bitcoin.user` / `bitcoin.password` descriptions
- `config.go`: `connect_bitcoin` description (lazy-connection note)
- `README.md`: notes under the Chain Backend section (ports, credentials, lazy connection + verification command)

No behavior changes.

## Verification

- `go build ./...` passes; `faraday --help` renders the updated descriptions correctly.
- The port table matches bitcoind's defaults; the 401-at-request-time symptom and the channel-close trigger are taken directly from the reproduction in #176.

Fixes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)