### PR TITLE
mod: bump go version and sqldb version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
   # /Dockerfile
   # /frdrpc/Dockerfile
   # /itest/Dockerfile
-  GO_VERSION: 1.25.10
+  GO_VERSION: 1.25.12
 
 jobs:
   ########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-alpine as builder
+FROM golang:1.25.12-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/chanevents/store.go
+++ b/chanevents/store.go
@@ -84,12 +84,10 @@ type BatchedSQLQueries interface {
 // SQLQueries is a subset of the sqlc.Queries interface that can be used to
 // interact with various chanevents tables.
 type SQLQueries interface {
-	sqldb.BaseQuerier
-
 	Queries
 }
 
-type SQLQueriesExecutor[T sqldb.BaseQuerier] struct {
+type SQLQueriesExecutor[T any] struct {
 	*sqldb.TransactionExecutor[T]
 
 	SQLQueries

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -1,5 +1,9 @@
 package db
 
+import (
+	"github.com/lightningnetwork/lnd/sqldb/v2"
+)
+
 const (
 	// LatestMigrationVersion is the latest migration version of the
 	// database. This is used to implement downgrade protection for the
@@ -8,3 +12,21 @@ const (
 	// NOTE: This MUST be updated when a new migration is added.
 	LatestMigrationVersion = 2
 )
+
+// MakeMigrationDescriptors returns the ordered migration descriptors for
+// faraday's SQL schema. Both migrations are schema-only, so neither carries a
+// programmatic migration step.
+func MakeMigrationDescriptors() []sqldb.MigrationDescriptor {
+	return []sqldb.MigrationDescriptor{
+		{
+			Name:          "chanevents",
+			Version:       1,
+			SchemaVersion: 1,
+		},
+		{
+			Name:          "chanevents_ts_idx",
+			Version:       2,
+			SchemaVersion: 2,
+		},
+	}
+}

--- a/db/sql_migrations.go
+++ b/db/sql_migrations.go
@@ -18,6 +18,7 @@ var (
 		//
 		// NOTE: This MUST be updated when a new migration is added.
 		LatestMigrationVersion: LatestMigrationVersion,
+		Descriptors:            MakeMigrationDescriptors(),
 
 		MakeProgrammaticMigrations: func(
 			db *sqldb.BaseDB,

--- a/frdrpc/Dockerfile
+++ b/frdrpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-bookworm
+FROM golang:1.25.12-bookworm
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/frdrpc/go.mod
+++ b/frdrpc/go.mod
@@ -20,4 +20,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.10
+go 1.25.12

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9
 	github.com/lightningnetwork/lnd/kvdb v1.4.16
-	github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0-20260326184657-f7cc56305bae
+	github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0
 	github.com/shopspring/decimal v1.2.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli v1.22.14

--- a/go.mod
+++ b/go.mod
@@ -196,4 +196,4 @@ replace github.com/golang-migrate/migrate/v4 => github.com/lightninglabs/migrate
 // We need to replace frdrpc locally until we have this PR merged.
 replace github.com/lightninglabs/faraday/frdrpc => ./frdrpc
 
-go 1.25.10
+go 1.25.12

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/lightningnetwork/lnd/queue v1.2.0 h1:sSrn+u84OLuOT/F+xGxgg8VfknXeIZEA
 github.com/lightningnetwork/lnd/queue v1.2.0/go.mod h1:qLNP0L3B7piRGvDyhAyJKic4xTt+Mw4D7mWrQeuAwxY=
 github.com/lightningnetwork/lnd/sqldb v1.0.13 h1:CcG9mrHNW/hIuZnqgosdiNmS7QhjSyfR/XkSFJB7EC8=
 github.com/lightningnetwork/lnd/sqldb v1.0.13/go.mod h1:ew3kMfknA0B4djTtrQSAkxvro+8+c++L8LuNaoT7GQA=
-github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0-20260326184657-f7cc56305bae h1:ICRuZIkXed43iuqcJaayubPTcQolttttwNZFrapdwIo=
-github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0-20260326184657-f7cc56305bae/go.mod h1:T2F1Sfb0oSpZyylIEE3ijiSejaXvIExER5xEdoe5wEE=
+github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0 h1:c0tt+rlsXCPmPlw641ruOe+EmeyFPWmD+E4sONaj0lc=
+github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0/go.mod h1:TyfjJz1iAKJA3uw3Tk7Mto0FJZY/MR5mAUc5qI80zB4=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.2 h1:MO4FCk7F4k5xPMqVZF6Nb/kOpxlwPrUQpYjmyKny5s0=

--- a/itest/Dockerfile
+++ b/itest/Dockerfile
@@ -2,7 +2,7 @@
 # base images. The first stage builds lnd with the golang base image.
 # The second stage runs directly on the bitcoind base image and adds all
 # binaries required to run the tests with.
-FROM golang:1.25.10-alpine as builder
+FROM golang:1.25.12-alpine as builder
 
 ARG LND_VERSION=v0.21.0-beta
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-bookworm
+FROM golang:1.25.12-bookworm
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -198,4 +198,4 @@ require (
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 )
 
-go 1.25.10
+go 1.25.12


### PR DESCRIPTION
This makes faraday compatible with the latest lit master branch.