### PR TITLE
config: support reading bitcoin rpc password from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ To connect Faraday to btcd:
 --bitcoin.tlspath={path to btcd cert}
 ```
 
+Instead of passing the password on the command line with `--bitcoin.password`,
+it can be read from a file with `--bitcoin.passwordfile`, which keeps the
+password out of the process list and shell history:
+```text
+--bitcoin.passwordfile={path to a file containing the rpc password}
+```
+`--bitcoin.password` and `--bitcoin.passwordfile` are mutually exclusive.
+
 #### RPCServer
 Faraday serves requests over grpc by default on `localhost:8465`. This default can be overwritten:
 ```text

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ To connect Faraday to btcd:
 
 Instead of passing the password on the command line with `--bitcoin.password`,
 it can be read from a file with `--bitcoin.passwordfile`, which keeps the
-password out of the process list and shell history:
+password out of the process list and shell history; surrounding whitespace
+and the trailing newline are stripped:
 ```text
 --bitcoin.passwordfile={path to a file containing the rpc password}
 ```

--- a/chain/client.go
+++ b/chain/client.go
@@ -23,6 +23,7 @@ type BitcoinConfig struct {
 	Host         string `long:"host" description:"host:port of the bitcoind/btcd instance address"`
 	User         string `long:"user" description:"bitcoind/btcd user name"`
 	Password     string `long:"password" description:"bitcoind/btcd password"`
+	PasswordFile string `long:"passwordfile" description:"path to a file containing the bitcoind/btcd password, as an alternative to --bitcoin.password"`
 	HTTPPostMode bool   `long:"httppostmode" description:"Use HTTP POST mode? bitcoind only supports this mode"`
 	UseTLS       bool   `long:"usetls" description:"Use TLS to connect? bitcoind only supports non-TLS connections"`
 	TLSPath      string `long:"tlspath" description:"Path to btcd tls certificate, bitcoind only supports non-TLS connections"`

--- a/config.go
+++ b/config.go
@@ -329,9 +329,11 @@ func ValidateConfig(config *Config) error {
 					"bitcoin.passwordfile: %v", err)
 			}
 
-			config.Bitcoin.Password = strings.TrimSpace(
-				string(pw),
-			)
+			config.Bitcoin.Password = strings.TrimSpace(string(pw))
+			if config.Bitcoin.Password == "" {
+				return fmt.Errorf("bitcoin.passwordfile %v "+
+					"is empty", pwPath)
+			}
 		}
 
 		if config.Bitcoin.User == "" || config.Bitcoin.Password == "" {

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -309,6 +310,30 @@ func ValidateConfig(config *Config) error {
 	// that we have a rpc user and password, and that tls path is set if
 	// required.
 	if config.ChainConn {
+		switch {
+		case config.Bitcoin.Password != "" &&
+			config.Bitcoin.PasswordFile != "":
+
+			return fmt.Errorf("bitcoin.password and " +
+				"bitcoin.passwordfile are mutually " +
+				"exclusive, please only set one")
+
+		case config.Bitcoin.PasswordFile != "":
+			pwPath := lncfg.CleanAndExpandPath(
+				config.Bitcoin.PasswordFile,
+			)
+
+			pw, err := os.ReadFile(pwPath)
+			if err != nil {
+				return fmt.Errorf("could not read "+
+					"bitcoin.passwordfile: %v", err)
+			}
+
+			config.Bitcoin.Password = strings.TrimSpace(
+				string(pw),
+			)
+		}
+
 		if config.Bitcoin.User == "" || config.Bitcoin.Password == "" {
 			return fmt.Errorf("rpc user and password " +
 				"required when chainconn is set")

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,103 @@
+package faraday
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newValidTestConfig returns a config that passes ValidateConfig other than
+// the bitcoin backend settings, which are set up by the individual test
+// cases below.
+func newValidTestConfig(t *testing.T) Config {
+	cfg := DefaultConfig()
+	cfg.FaradayDir = t.TempDir()
+	cfg.ChainConn = true
+
+	// DefaultConfig points Bitcoin at the shared chain.DefaultConfig
+	// instance, so copy it before mutating to avoid leaking state
+	// across test cases.
+	bitcoinCfg := *cfg.Bitcoin
+	cfg.Bitcoin = &bitcoinCfg
+	cfg.Bitcoin.User = "user"
+
+	return cfg
+}
+
+// TestValidateConfigBitcoinPassword tests that ValidateConfig correctly
+// resolves the bitcoind/btcd RPC password from either the plaintext
+// --bitcoin.password flag or from a file referenced by
+// --bitcoin.passwordfile, and rejects invalid combinations of the two.
+func TestValidateConfigBitcoinPassword(t *testing.T) {
+	t.Parallel()
+
+	pwFile := filepath.Join(t.TempDir(), "pw.txt")
+	err := os.WriteFile(pwFile, []byte("filepassword\n"), 0644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		setup       func(cfg *Config)
+		expectedPw  string
+		expectedErr string
+	}{
+		{
+			name: "plaintext password",
+			setup: func(cfg *Config) {
+				cfg.Bitcoin.Password = "plainpassword"
+			},
+			expectedPw: "plainpassword",
+		},
+		{
+			name: "password file",
+			setup: func(cfg *Config) {
+				cfg.Bitcoin.PasswordFile = pwFile
+			},
+			expectedPw: "filepassword",
+		},
+		{
+			name: "password file does not exist",
+			setup: func(cfg *Config) {
+				cfg.Bitcoin.PasswordFile = filepath.Join(
+					t.TempDir(), "missing.txt",
+				)
+			},
+			expectedErr: "could not read bitcoin.passwordfile",
+		},
+		{
+			name: "password and password file set",
+			setup: func(cfg *Config) {
+				cfg.Bitcoin.Password = "plainpassword"
+				cfg.Bitcoin.PasswordFile = pwFile
+			},
+			expectedErr: "mutually exclusive",
+		},
+		{
+			name:        "neither password nor password file set",
+			setup:       func(cfg *Config) {},
+			expectedErr: "rpc user and password required",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := newValidTestConfig(t)
+			test.setup(&cfg)
+
+			err := ValidateConfig(&cfg)
+			if test.expectedErr != "" {
+				require.ErrorContains(t, err, test.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.expectedPw, cfg.Bitcoin.Password)
+		})
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -37,6 +37,10 @@ func TestValidateConfigBitcoinPassword(t *testing.T) {
 	err := os.WriteFile(pwFile, []byte("filepassword\n"), 0644)
 	require.NoError(t, err)
 
+	emptyPwFile := filepath.Join(t.TempDir(), "empty-pw.txt")
+	err = os.WriteFile(emptyPwFile, []byte("  \n"), 0644)
+	require.NoError(t, err)
+
 	tests := []struct {
 		name        string
 		setup       func(cfg *Config)
@@ -65,6 +69,13 @@ func TestValidateConfigBitcoinPassword(t *testing.T) {
 				)
 			},
 			expectedErr: "could not read bitcoin.passwordfile",
+		},
+		{
+			name: "password file is empty",
+			setup: func(cfg *Config) {
+				cfg.Bitcoin.PasswordFile = emptyPwFile
+			},
+			expectedErr: "is empty",
 		},
 		{
 			name: "password and password file set",


### PR DESCRIPTION
## Summary

Adds a `--bitcoin.passwordfile` config option as an alternative to
`--bitcoin.password`, so operators can point faraday at a file
containing the bitcoind/btcd RPC password instead of putting it in
plaintext on the command line or in a docker-compose manifest.

- `chain.BitcoinConfig` gains a `PasswordFile` field
  (`--bitcoin.passwordfile`).
- `ValidateConfig` resolves the password from the file when
  `--bitcoin.passwordfile` is set, trimming surrounding whitespace and
  the trailing newline, and rejects the config if both
  `--bitcoin.password` and `--bitcoin.passwordfile` are set, if the
  file can't be read, or if it's empty.
- README documents the new flag.

Closes #252.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race .` (new `TestValidateConfigBitcoinPassword` covers
      the plaintext flag, the file flag, a missing file, an empty
      file, and the mutually-exclusive-flags case)
- [x] `go test ./...` (itest failures are pre-existing/unrelated —
      that suite requires a live bitcoind/lnd docker environment)