### PR TITLE
version: bump to `v0.2.19`

### DIFF
--- a/version.go
+++ b/version.go
@@ -25,7 +25,7 @@ const (
 	// Please update release_notes.md when updating this!
 	appMajor uint = 0
 	appMinor uint = 2
-	appPatch uint = 18
+	appPatch uint = 19
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
This PR bumps the `faraday` version to `v0.2.19`.